### PR TITLE
fix: icon size cannot be changed

### DIFF
--- a/packages/documentation/src/modules/App/App.tsx
+++ b/packages/documentation/src/modules/App/App.tsx
@@ -7,7 +7,7 @@ const {
 	ButtonIcon,
 	ButtonLink,
 	Footer,
-	IconAssistant,
+	IconDogInShield,
 	IconClose,
 	IconCopied,
 	IconCopy,
@@ -109,7 +109,7 @@ function App() {
 						<IconDog className={"h-9 w-9"} />
 					</Section>
 					<Section kind="light">
-						<IconAssistant />
+						<IconDogInShield />
 						<IconClose />
 						<IconCopied />
 						<IconCopy />

--- a/packages/documentation/src/modules/App/App.tsx
+++ b/packages/documentation/src/modules/App/App.tsx
@@ -106,7 +106,7 @@ function App() {
 				<section>
 					<h2>Icons</h2>
 					<Section kind="light">
-						<IconDog className={"h-9 w-9"} />
+						<IconDog className={"h-9 w-full"} />
 					</Section>
 					<Section kind="light">
 						<IconDogInShield />

--- a/packages/ui-components/src/components/Icons/IconClose.tsx
+++ b/packages/ui-components/src/components/Icons/IconClose.tsx
@@ -1,9 +1,8 @@
-import clsx from "clsx";
-
+import { defaultIconSize } from "./constants";
 import type { IconsProps } from "./IconsTypes";
 
 export const IconClose = ({ className }: IconsProps) => {
-	const generatedClassName = clsx("h-5 w-5", className);
+	const generatedClassName = className ? className : defaultIconSize;
 
 	return (
 		<svg

--- a/packages/ui-components/src/components/Icons/IconCopied.tsx
+++ b/packages/ui-components/src/components/Icons/IconCopied.tsx
@@ -1,9 +1,8 @@
-import clsx from "clsx";
-
+import { defaultIconSize } from "./constants";
 import type { IconsProps } from "./IconsTypes";
 
 export const IconCopied = ({ className }: IconsProps) => {
-	const generatedClassName = clsx("h-5 w-5", className);
+	const generatedClassName = className ? className : defaultIconSize;
 
 	return (
 		<svg

--- a/packages/ui-components/src/components/Icons/IconCopy.tsx
+++ b/packages/ui-components/src/components/Icons/IconCopy.tsx
@@ -1,9 +1,8 @@
-import clsx from "clsx";
-
+import { defaultIconSize } from "./constants";
 import type { IconsProps } from "./IconsTypes";
 
 export const IconCopy = ({ className }: IconsProps) => {
-	const generatedClassName = clsx("h-5 w-5", className);
+	const generatedClassName = className ? className : defaultIconSize;
 
 	return (
 		<svg

--- a/packages/ui-components/src/components/Icons/IconDelete.tsx
+++ b/packages/ui-components/src/components/Icons/IconDelete.tsx
@@ -1,9 +1,8 @@
-import clsx from "clsx";
-
+import { defaultIconSize } from "./constants";
 import type { IconsProps } from "./IconsTypes";
 
 export const IconDelete = ({ className }: IconsProps) => {
-	const generatedClassName = clsx("h-5 w-5", className);
+	const generatedClassName = className ? className : defaultIconSize;
 
 	return (
 		<svg

--- a/packages/ui-components/src/components/Icons/IconDog.tsx
+++ b/packages/ui-components/src/components/Icons/IconDog.tsx
@@ -1,9 +1,7 @@
-import clsx from "clsx";
-
 import type { IconsProps } from "./IconsTypes";
 
 export const IconDog = ({ className }: IconsProps) => {
-	const generatedClassName = clsx("w-full", className);
+	const generatedClassName = className ? className : "w-full";
 	return (
 		<svg
 			xmlns="http://www.w3.org/2000/svg"

--- a/packages/ui-components/src/components/Icons/IconDogInShield.tsx
+++ b/packages/ui-components/src/components/Icons/IconDogInShield.tsx
@@ -1,9 +1,8 @@
-import clsx from "clsx";
-
+import { defaultIconSize } from "./constants";
 import type { IconsProps } from "./IconsTypes";
 
-export const IconAssistant = ({ className }: IconsProps) => {
-	const generatedClassName = clsx("h-5 w-5", className);
+export const IconDogInShield = ({ className }: IconsProps) => {
+	const generatedClassName = className ? className : defaultIconSize;
 
 	return (
 		<svg

--- a/packages/ui-components/src/components/Icons/IconEdit.tsx
+++ b/packages/ui-components/src/components/Icons/IconEdit.tsx
@@ -1,9 +1,8 @@
-import clsx from "clsx";
-
+import { defaultIconSize } from "./constants";
 import type { IconsProps } from "./IconsTypes";
 
 export const IconEdit = ({ className }: IconsProps) => {
-	const generatedClassName = clsx("h-5 w-5", className);
+	const generatedClassName = className ? className : defaultIconSize;
 	return (
 		<svg
 			xmlns="http://www.w3.org/2000/svg"

--- a/packages/ui-components/src/components/Icons/IconRestore.tsx
+++ b/packages/ui-components/src/components/Icons/IconRestore.tsx
@@ -1,9 +1,8 @@
-import clsx from "clsx";
-
+import { defaultIconSize } from "./constants";
 import type { IconsProps } from "./IconsTypes";
 
 export const IconRestore = ({ className }: IconsProps) => {
-	const generatedClassName = clsx("h-5 w-5", className);
+	const generatedClassName = className ? className : defaultIconSize;
 
 	return (
 		<svg

--- a/packages/ui-components/src/components/Icons/IconSettings.tsx
+++ b/packages/ui-components/src/components/Icons/IconSettings.tsx
@@ -1,9 +1,8 @@
-import clsx from "clsx";
-
+import { defaultIconSize } from "./constants";
 import type { IconsProps } from "./IconsTypes";
 
 export const IconSettings = ({ className }: IconsProps) => {
-	const generatedClassName = clsx("h-5 w-5", className);
+	const generatedClassName = className ? className : defaultIconSize;
 
 	return (
 		<svg

--- a/packages/ui-components/src/components/Icons/IconUser.tsx
+++ b/packages/ui-components/src/components/Icons/IconUser.tsx
@@ -1,9 +1,8 @@
-import clsx from "clsx";
-
+import { defaultIconSize } from "./constants";
 import type { IconsProps } from "./IconsTypes";
 
 export const IconUser = ({ className }: IconsProps) => {
-	const generatedClassName = clsx("h-5 w-5", className);
+	const generatedClassName = className ? className : defaultIconSize;
 
 	return (
 		<svg

--- a/packages/ui-components/src/components/Icons/constants.ts
+++ b/packages/ui-components/src/components/Icons/constants.ts
@@ -1,0 +1,1 @@
+export const defaultIconSize = "h-5 w-5";

--- a/packages/ui-components/src/components/index.ts
+++ b/packages/ui-components/src/components/index.ts
@@ -2,12 +2,12 @@ import { Button } from "./Button/Button";
 import { ButtonIcon } from "./Button/ButtonIcon";
 import { ButtonLink } from "./Button/ButtonLink";
 import { Footer } from "./Footer/Footer";
-import { IconAssistant } from "./Icons/IconAssistant";
 import { IconClose } from "./Icons/IconClose";
 import { IconCopied } from "./Icons/IconCopied";
 import { IconCopy } from "./Icons/IconCopy";
 import { IconDelete } from "./Icons/IconDelete";
 import { IconDog } from "./Icons/IconDog";
+import { IconDogInShield } from "./Icons/IconDogInShield";
 import { IconEdit } from "./Icons/IconEdit";
 import { IconRestore } from "./Icons/IconRestore";
 import { IconSettings } from "./Icons/IconSettings";
@@ -18,12 +18,12 @@ export {
 	ButtonIcon,
 	ButtonLink,
 	Footer,
-	IconAssistant,
 	IconClose,
 	IconCopied,
 	IconCopy,
 	IconDelete,
 	IconDog,
+	IconDogInShield,
 	IconEdit,
 	IconRestore,
 	IconSettings,


### PR DESCRIPTION
fix: renamed IconAssistant into IconDogInShield

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Renamed `IconAssistant` to `IconDogInShield` across the application.
	- Simplified class name generation logic in various Icon components by removing `clsx` library and using `defaultIconSize` from constants.
- **New Features**
	- Introduced `defaultIconSize` in Icon constants for consistent icon sizing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->