### PR TITLE
fix: slim button label not visible at lower breakpoint

### DIFF
--- a/packages/ui-components/src/components/Button/__tests__/Button.test.tsx
+++ b/packages/ui-components/src/components/Button/__tests__/Button.test.tsx
@@ -44,25 +44,19 @@ describe("Button modifiers", () => {
 	it("should render a slim button", async () => {
 		render(<Button slim>hello</Button>);
 		const button = await screen.findByRole("button");
-		expect(button.className).toContain("px-2");
-		expect(button.className).toContain("py-1");
-		expect(button.className).toContain("sm:px-4");
+		expectToHaveClasses(button, ["px-2", "py-1", "sm:px-4"]);
 	});
 
 	it("should render a dark button", async () => {
 		render(<Button kind="dark">hello</Button>);
 		const button = await screen.findByRole("button");
-		const buttonClass = button.className;
-		expect(buttonClass).toContain("text-slate-200");
-		expect(buttonClass).toContain("bg-slate-900");
+		expectToHaveClasses(button, ["bg-slate-900", "text-slate-200"]);
 	});
 
 	it("should render a light button", async () => {
 		render(<Button kind="light">hello</Button>);
 		const button = await screen.findByRole("button");
-		const buttonClass = button.className;
-		expect(buttonClass).toContain("text-slate-200");
-		expect(buttonClass).toContain("bg-slate-500");
+		expectToHaveClasses(button, ["bg-slate-500", "text-slate-200"]);
 	});
 
 	it("should render a disabled dark button", async () => {
@@ -72,9 +66,10 @@ describe("Button modifiers", () => {
 			</Button>,
 		);
 		const button = await screen.findByRole("button");
-		const buttonClass = button.className;
-		expect(buttonClass).toContain("disabled:opacity-50");
-		expect(buttonClass).toContain("disabled:cursor-not-allowed");
+		expectToHaveClasses(button, [
+			"disabled:opacity-50",
+			"disabled:cursor-not-allowed",
+		]);
 	});
 
 	it("should render a disabled light button", async () => {
@@ -84,9 +79,10 @@ describe("Button modifiers", () => {
 			</Button>,
 		);
 		const button = await screen.findByRole("button");
-		const buttonClass = button.className;
-		expect(buttonClass).toContain("disabled:opacity-50");
-		expect(buttonClass).toContain("disabled:cursor-not-allowed");
+		expectToHaveClasses(button, [
+			"disabled:opacity-50",
+			"disabled:cursor-not-allowed",
+		]);
 	});
 
 	it("should render a fullWidth button", async () => {

--- a/packages/ui-components/src/components/Button/__tests__/Button.test.tsx
+++ b/packages/ui-components/src/components/Button/__tests__/Button.test.tsx
@@ -5,6 +5,13 @@ import userEvent from "@testing-library/user-event";
 
 import { Button } from "../..";
 
+const expectToHaveClasses = (element: HTMLElement, classes: string[]) => {
+	const elementClasses = element.className.split(" ").sort();
+	classes.forEach((expectedClass) => {
+		expect(elementClasses).toContain(expectedClass);
+	});
+};
+
 describe("Button (exceptions)", () => {
 	it("should be able to require/import from root", () => {
 		expect(Button).toBeDefined();
@@ -15,13 +22,31 @@ describe("Button modifiers", () => {
 	it("should render a default button", async () => {
 		render(<Button>hello</Button>);
 		const button = await screen.findByRole("button");
-		expect(button.className).toContain("py-2");
+		expectToHaveClasses(button, [
+			"av-button",
+			"px-4",
+			"py-2",
+			"text-sm",
+			"font-medium",
+			"sm:text-base",
+			"bg-slate-900",
+			"text-slate-200",
+			"hover:bg-slate-800",
+			"active:bg-slate-700",
+			"rounded-full",
+			"focus:outline-none",
+			"focus:ring-2",
+			"focus:ring-slate-300",
+			"focus:ring-offset-0",
+		]);
 	});
 
 	it("should render a slim button", async () => {
 		render(<Button slim>hello</Button>);
 		const button = await screen.findByRole("button");
+		expect(button.className).toContain("px-2");
 		expect(button.className).toContain("py-1");
+		expect(button.className).toContain("sm:px-4");
 	});
 
 	it("should render a dark button", async () => {

--- a/packages/ui-components/src/components/Button/utilities.ts
+++ b/packages/ui-components/src/components/Button/utilities.ts
@@ -21,7 +21,7 @@ const getButtonClassesByType = (type: string, slim?: boolean) => {
 		case TYPE_BUTTON:
 			return clsx("text-sm font-medium sm:text-base", {
 				"px-4 py-2": !slim,
-				"px-0 py-1 sm:px-4": slim,
+				"px-2 py-1 sm:px-4": slim,
 			});
 		case TYPE_LINK:
 			return clsx("max-h-8 px-0 py-1 text-center text-sm sm:px-4", {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved button component tests by introducing a new utility function for class assertions.
  
- **Style**
  - Adjusted button padding for a better visual appearance when the `slim` option is used.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->