### PR TITLE
feat(TextInput): adding support for a right element

### DIFF
--- a/packages/documentation/src/stories/TextInput.stories.tsx
+++ b/packages/documentation/src/stories/TextInput.stories.tsx
@@ -1,10 +1,10 @@
 import type { Meta, StoryObj } from "@storybook/react";
-import { TextInput } from "@versini/ui-components";
+import { Button, TextInput } from "@versini/ui-components";
 
 const meta: Meta<typeof TextInput> = {
 	component: TextInput,
 	parameters: {
-		controls: { exclude: ["spacing"], sort: "requiredFirst" },
+		controls: { exclude: ["spacing", "rightElement"], sort: "requiredFirst" },
 	},
 	args: {
 		type: "text",
@@ -62,6 +62,26 @@ export default meta;
 type Story = StoryObj<typeof TextInput>;
 
 export const Basic: Story = {
+	render: (args) => (
+		<div className="min-h-10 bg-slate-500 p-11">
+			<form noValidate>
+				<div className="flex gap-2">
+					<TextInput {...args} />
+				</div>
+			</form>
+		</div>
+	),
+};
+
+export const RightElement: Story = {
+	args: {
+		rightElement: (
+			<Button kind="light" noBorder>
+				Send
+			</Button>
+		),
+		helperText: "Powered by the sun",
+	},
 	render: (args) => (
 		<div className="min-h-10 bg-slate-500 p-11">
 			<form noValidate>

--- a/packages/ui-components/src/components/TextInput/TextInput.tsx
+++ b/packages/ui-components/src/components/TextInput/TextInput.tsx
@@ -23,6 +23,8 @@ export const TextInput = ({
 
 	helperText = "",
 
+	rightElement,
+
 	...extraProps
 }: TextInputProps) => {
 	const inputId = useUniqueId({ id, prefix: "av-text-input-" });
@@ -74,6 +76,13 @@ export const TextInput = ({
 					{helperText}
 				</div>
 			)}
+
+			{rightElement && (
+				<span className="av-text-input__control av-text-input__control--right">
+					{rightElement}
+				</span>
+			)}
+
 			{error && helperText && (
 				<LiveRegion politeness="polite" clearAnnouncementDelay={500}>
 					{liveErrorMessage}

--- a/packages/ui-components/src/components/TextInput/TextInput.tsx
+++ b/packages/ui-components/src/components/TextInput/TextInput.tsx
@@ -78,9 +78,7 @@ export const TextInput = ({
 			)}
 
 			{rightElement && (
-				<span className="av-text-input__control av-text-input__control--right">
-					{rightElement}
-				</span>
+				<span className="av-text-input__control--right">{rightElement}</span>
 			)}
 
 			{error && helperText && (

--- a/packages/ui-components/src/components/TextInput/TextInputTypes.d.ts
+++ b/packages/ui-components/src/components/TextInput/TextInputTypes.d.ts
@@ -10,4 +10,5 @@ export type TextInputProps = {
 	raw?: boolean;
 	noBorder?: boolean;
 	inputClassName?: string;
+	rightElement?: React.ReactElement;
 } & React.InputHTMLAttributes<HTMLInputElement>;

--- a/packages/ui-components/src/components/TextInput/__tests__/TextInput.test.tsx
+++ b/packages/ui-components/src/components/TextInput/__tests__/TextInput.test.tsx
@@ -58,7 +58,13 @@ describe("TextInput modifiers", () => {
 		);
 		const input = await screen.findByTestId("txtnpt-1");
 		expect(input.className).not.toContain("toto");
-		expect(input.parentElement?.className).toContain("toto");
+		if (input.parentElement) {
+			expectToHaveClasses(input.parentElement, [
+				"toto",
+				"w-full",
+				"justify-center",
+			]);
+		}
 	});
 
 	it("should render a text input with an input class", async () => {

--- a/packages/ui-components/src/components/TextInput/__tests__/TextInput.test.tsx
+++ b/packages/ui-components/src/components/TextInput/__tests__/TextInput.test.tsx
@@ -84,8 +84,10 @@ describe("TextInput modifiers", () => {
 				data-testid="txtnpt-1"
 			/>,
 		);
-		const input = await screen.findByTestId("txtnpt-1");
-		expect(input.parentElement?.lastChild?.textContent).toBe("right element");
+		const rightElement = await screen.findByText("right element");
+		expect(rightElement?.parentElement?.className).toContain(
+			"av-text-input__control--right",
+		);
 	});
 });
 

--- a/packages/ui-components/src/components/TextInput/__tests__/TextInput.test.tsx
+++ b/packages/ui-components/src/components/TextInput/__tests__/TextInput.test.tsx
@@ -74,6 +74,19 @@ describe("TextInput modifiers", () => {
 		expect(input.className).toContain("toto");
 		expect(input.parentElement?.className).not.toContain("toto");
 	});
+
+	it("should render a text input with a right element", async () => {
+		render(
+			<TextInput
+				label="toto"
+				name="toto"
+				rightElement={<div>right element</div>}
+				data-testid="txtnpt-1"
+			/>,
+		);
+		const input = await screen.findByTestId("txtnpt-1");
+		expect(input.parentElement?.lastChild?.textContent).toBe("right element");
+	});
 });
 
 describe("TextInput methods", () => {

--- a/packages/ui-components/src/components/TextInput/utilities.ts
+++ b/packages/ui-components/src/components/TextInput/utilities.ts
@@ -117,7 +117,7 @@ export const getTextInputClasses = ({
 }: getTextInputClassesProps) => {
 	const wrapper = raw
 		? className
-		: clsx(`${TEXT_INPUT_WRAPPER_CLASSNAME} w-full`, className);
+		: clsx(`${TEXT_INPUT_WRAPPER_CLASSNAME} w-full justify-center`, className);
 
 	const input = raw
 		? inputClassName

--- a/packages/ui-components/src/components/index.css
+++ b/packages/ui-components/src/components/index.css
@@ -28,7 +28,7 @@
 	.av-text-input-wrapper label {
 		position: absolute;
 		/* move the label inline */
-		transform: translate(18px, 28px) scale(1);
+		transform: translate(18px, 0) scale(1);
 		transform-origin: top left;
 		transition: all 0.2s ease-out;
 	}
@@ -53,13 +53,18 @@
 	.av-text-input:focus + label,
 	.av-text-input:not(:placeholder-shown) + label {
 		/* move the label up */
-		transform: translate(18px, 2px) scale(0.75);
+		transform: translate(18px, -25px) scale(0.75);
 	}
 
 	.av-text-input-helper-text {
 		position: absolute;
-		transform: translate(18px, 59px) scale(0.75);
+		transform: translate(18px, 30px) scale(0.75);
 		transform-origin: top left;
 		transition: all 0.2s ease-out;
+	}
+
+	.av-text-input__control--right {
+		position: absolute;
+		right: 18px;
 	}
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a `rightElement` prop for the `TextInput` component, allowing users to add custom elements to the right side of the input field.

- **Documentation**
  - Updated TextInput component stories to showcase the new `rightElement` feature.

- **Style**
  - Implemented new styles for positioning the `rightElement` within the `TextInput` component.

- **Tests**
  - Added test cases to verify the correct rendering of the `TextInput` with the `rightElement`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->