### PR TITLE
fix(TextInput): right element should not be enclosed in span

### DIFF
--- a/packages/ui-components/src/components/TextInput/TextInput.tsx
+++ b/packages/ui-components/src/components/TextInput/TextInput.tsx
@@ -34,7 +34,7 @@ export const TextInput = React.forwardRef<HTMLInputElement, TextInputProps>(
 		},
 		ref,
 	) => {
-		const rightElementRef = useRef<HTMLSpanElement>(null);
+		const rightElementRef = useRef<HTMLDivElement>(null);
 		const [inputPaddingRight, setInputPaddingRight] = useState(0);
 		const inputId = useUniqueId({ id, prefix: `${TEXT_INPUT_CLASSNAME}-` });
 		const liveErrorMessage = `${name} error, ${helperText}`;
@@ -99,12 +99,12 @@ export const TextInput = React.forwardRef<HTMLInputElement, TextInputProps>(
 				)}
 
 				{rightElement && (
-					<span
+					<div
 						ref={rightElementRef}
 						className={textInputClassName.rightElement}
 					>
 						{rightElement}
-					</span>
+					</div>
 				)}
 
 				{error && helperText && (


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated the `TextInput` component to enhance compatibility and flexibility with various content types by changing the wrapping element of the `rightElement`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->