### PR TITLE
fix: replacing visually-hidden class with sr-only from Tailwind

### DIFF
--- a/packages/ui-components/src/common/constants.ts
+++ b/packages/ui-components/src/common/constants.ts
@@ -19,7 +19,6 @@ export const FLEXGRID_ITEM_CLASSNAME = "av-flexgrid-item";
 export const CARD_CLASSNAME = "av-card";
 export const SPINNER_CLASSNAME = "av-spinner";
 
-export const VISUALLY_HIDDEN_CLASSNAME = "av-visually-hidden";
 export const TRUNCATE_CLASSNAME = "av-truncate-text";
 
 export const FLEXGRID_MAX_COLUMNS = 12;

--- a/packages/ui-components/src/components/Spinner/Spinner.tsx
+++ b/packages/ui-components/src/components/Spinner/Spinner.tsx
@@ -1,9 +1,6 @@
 import clsx from "clsx";
 
-import {
-	SPINNER_CLASSNAME,
-	VISUALLY_HIDDEN_CLASSNAME,
-} from "../../common/constants";
+import { SPINNER_CLASSNAME } from "../../common/constants";
 import type { SpinnerProps } from "./SpinnerTypes";
 
 export const Spinner = ({ spinnerRef, kind = "dark" }: SpinnerProps) => {
@@ -17,7 +14,7 @@ export const Spinner = ({ spinnerRef, kind = "dark" }: SpinnerProps) => {
 	);
 	return (
 		<div ref={spinnerRef} className={spinnerClassName} role="status">
-			<span className={VISUALLY_HIDDEN_CLASSNAME}>Loading...</span>
+			<span className="sr-only">Loading...</span>
 		</div>
 	);
 };

--- a/packages/ui-components/src/components/TextArea/__tests__/TextArea.test.tsx
+++ b/packages/ui-components/src/components/TextArea/__tests__/TextArea.test.tsx
@@ -17,7 +17,7 @@ describe("TextArea modifiers", () => {
 	it("should render a default text area", async () => {
 		render(<TextArea label="hello world" name="toto" />);
 		const input = await screen.findAllByText("hello world");
-		expect(input[0].className).toContain("av-visually-hidden");
+		expect(input[0].className).toContain("sr-only");
 		expectToHaveClasses(input[1], ["cursor-text", "text-copy-medium"]);
 	});
 

--- a/packages/ui-components/src/components/TextArea/utilities.ts
+++ b/packages/ui-components/src/components/TextArea/utilities.ts
@@ -5,7 +5,6 @@ import {
 	TEXT_AREA_CONTROL_RIGHT_CLASSNAME,
 	TEXT_AREA_HELPER_TEXT_CLASSNAME,
 	TEXT_AREA_WRAPPER_CLASSNAME,
-	VISUALLY_HIDDEN_CLASSNAME,
 } from "../../common/constants";
 
 type getTextAreaClassesProps = {
@@ -143,7 +142,7 @@ export const getTextAreaClasses = ({
 				},
 		  );
 
-	const accessibleLabel = raw ? undefined : VISUALLY_HIDDEN_CLASSNAME;
+	const accessibleLabel = raw ? undefined : "sr-only";
 
 	const visibleLabel = getTextAreaLabelClasses({
 		disabled,

--- a/packages/ui-components/src/components/TextInput/__tests__/TextInput.test.tsx
+++ b/packages/ui-components/src/components/TextInput/__tests__/TextInput.test.tsx
@@ -17,7 +17,7 @@ describe("TextInput modifiers", () => {
 	it("should render a default text input", async () => {
 		render(<TextInput label="hello world" name="toto" />);
 		const input = await screen.findAllByText("hello world");
-		expect(input[0].className).toContain("av-visually-hidden");
+		expect(input[0].className).toContain("sr-only");
 		expectToHaveClasses(input[1], ["cursor-text", "text-copy-medium"]);
 	});
 

--- a/packages/ui-components/src/components/TextInput/__tests__/TextInputMask.test.tsx
+++ b/packages/ui-components/src/components/TextInput/__tests__/TextInputMask.test.tsx
@@ -23,7 +23,7 @@ describe("TextInputMask modifiers", () => {
 	it("should render a default text input", async () => {
 		render(<TextInputMask label="hello world" name="toto" />);
 		const input = await screen.findAllByText("hello world");
-		expect(input[0].className).toContain("av-visually-hidden");
+		expect(input[0].className).toContain("sr-only");
 		expectToHaveClasses(input[1], ["cursor-text", "text-copy-medium"]);
 	});
 

--- a/packages/ui-components/src/components/TextInput/utilities.ts
+++ b/packages/ui-components/src/components/TextInput/utilities.ts
@@ -5,7 +5,6 @@ import {
 	TEXT_INPUT_CONTROL_RIGHT_CLASSNAME,
 	TEXT_INPUT_HELPER_TEXT_CLASSNAME,
 	TEXT_INPUT_WRAPPER_CLASSNAME,
-	VISUALLY_HIDDEN_CLASSNAME,
 } from "../../common/constants";
 
 type getTextInputClassesProps = {
@@ -139,7 +138,7 @@ export const getTextInputClasses = ({
 				},
 		  );
 
-	const accessibleLabel = raw ? undefined : VISUALLY_HIDDEN_CLASSNAME;
+	const accessibleLabel = raw ? undefined : "sr-only";
 
 	const visibleLabel = getTextInputLabelClasses({
 		disabled,

--- a/packages/ui-components/src/components/index.css
+++ b/packages/ui-components/src/components/index.css
@@ -3,21 +3,6 @@
 @tailwind utilities;
 
 @layer utilities {
-	.av-visually-hidden {
-		border: -0;
-		clip-path: inset(50%);
-		font-size: 1px;
-		height: 0;
-		left: 0;
-		margin: 0;
-		overflow: hidden;
-		padding: 0;
-		position: absolute;
-		top: 0;
-		white-space: nowrap;
-		width: 0;
-	}
-
 	.av-truncate-text {
 		overflow: hidden;
 		text-overflow: ellipsis;

--- a/packages/ui-components/src/components/private/LiveRegion/LiveRegion.tsx
+++ b/packages/ui-components/src/components/private/LiveRegion/LiveRegion.tsx
@@ -1,7 +1,6 @@
 import clsx from "clsx";
 import { useEffect, useReducer, useRef } from "react";
 
-import { VISUALLY_HIDDEN_CLASSNAME } from "../../../common/constants";
 import { DEFAULT_POLITENESS_BY_ROLE } from "./constants";
 import type { LiveRegionProps } from "./LiveRegionTypes";
 import { reducer } from "./reducer";
@@ -59,7 +58,7 @@ export function LiveRegion({
 	]);
 
 	const generatedClassName = clsx(className, {
-		[VISUALLY_HIDDEN_CLASSNAME]: !visible,
+		"sr-only": !visible,
 	});
 
 	return (

--- a/packages/ui-components/src/components/private/LiveRegion/__tests__/LiveRegion.test.tsx
+++ b/packages/ui-components/src/components/private/LiveRegion/__tests__/LiveRegion.test.tsx
@@ -1,7 +1,6 @@
 import { act, fireEvent, render } from "@testing-library/react";
 import React from "react";
 
-import { VISUALLY_HIDDEN_CLASSNAME } from "../../../../common/constants";
 import {
 	ACTION_CLEAR_ANNOUNCEMENT,
 	ACTION_SET_ANNOUNCEMENT,
@@ -287,7 +286,7 @@ describe(`The LiveRegion Component`, () => {
 		it("Then the content should be visible in the DOM", () => {
 			const { container } = render(<LiveRegion visible>Foo</LiveRegion>);
 
-			expect(container.firstChild).not.toHaveClass(VISUALLY_HIDDEN_CLASSNAME);
+			expect(container.firstChild).not.toHaveClass("sr-only");
 		});
 	});
 
@@ -339,9 +338,7 @@ describe(`The LiveRegion Component`, () => {
 						});
 
 						it(`Then the content is visually hidden`, () => {
-							expect(renderResult.container.firstChild).toHaveClass(
-								VISUALLY_HIDDEN_CLASSNAME,
-							);
+							expect(renderResult.container.firstChild).toHaveClass("sr-only");
 						});
 
 						describe(`And the "children" prop changes`, () => {

--- a/packages/ui-components/src/components/private/SvgIcon/SvgIcon.tsx
+++ b/packages/ui-components/src/components/private/SvgIcon/SvgIcon.tsx
@@ -1,6 +1,5 @@
 import clsx from "clsx";
 
-import { VISUALLY_HIDDEN_CLASSNAME } from "../../../common/constants";
 import { getSpacing } from "../../../common/utilities";
 import type { SvgIconProps } from "./SvgIconTypes";
 
@@ -35,9 +34,7 @@ export const SvgIcon = ({
 			>
 				{children}
 			</svg>
-			{title && !decorative && (
-				<span className={VISUALLY_HIDDEN_CLASSNAME}>{title}</span>
-			)}
+			{title && !decorative && <span className="sr-only">{title}</span>}
 		</>
 	);
 };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated visual hiding CSS class across various components for improved accessibility.

- **Style**
  - Removed outdated visual hiding class and replaced it with a modern equivalent.

- **Tests**
  - Adjusted test cases to reflect the updated class name for visually hidden elements.

- **Documentation**
  - No visible changes to end-user documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->