### PR TITLE
refactor: mergeRefs into useMergeRegs hook

### DIFF
--- a/packages/ui-components/src/common/__tests__/utilities.test.tsx
+++ b/packages/ui-components/src/common/__tests__/utilities.test.tsx
@@ -1,8 +1,6 @@
-import { render } from "@testing-library/react";
-import * as React from "react";
 import { describe, expect, it } from "vitest";
 
-import { getSpacing, isEmpty, mergeRefs, truncate } from "../utilities";
+import { getSpacing, isEmpty, truncate } from "../utilities";
 
 describe("Non-DOM tests", () => {
 	describe("getSpacing", () => {
@@ -66,33 +64,6 @@ describe("Non-DOM tests", () => {
 			expect(isEmpty(set)).toBe(true);
 			set.add(42);
 			expect(isEmpty(set)).toBe(false);
-		});
-	});
-});
-
-describe("DOM tests", () => {
-	describe("when testing for mergeRefs", () => {
-		it("should combine multiple refs of different types", () => {
-			const Dummy = React.forwardRef(function Dummy(_, ref) {
-				React.useImperativeHandle(ref, () => "refValue");
-				return null;
-			});
-			const refAsFunc = vi.fn();
-			const refAsObj = { current: undefined };
-			const Example: React.FC<{ visible: boolean }> = ({ visible }) => {
-				return visible ? (
-					<Dummy ref={mergeRefs([refAsObj, refAsFunc])} />
-				) : null;
-			};
-			const { rerender } = render(<Example visible />);
-			expect(refAsFunc).toHaveBeenCalledTimes(1);
-			expect(refAsFunc).toHaveBeenCalledWith("refValue");
-			expect(refAsObj.current).toBe("refValue");
-
-			rerender(<Example visible={false} />);
-			expect(refAsFunc).toHaveBeenCalledTimes(2);
-			expect(refAsFunc).toHaveBeenCalledWith(null);
-			expect(refAsObj.current).toBe(null);
 		});
 	});
 });

--- a/packages/ui-components/src/common/hooks/__tests__/useMergeRefs.test.tsx
+++ b/packages/ui-components/src/common/hooks/__tests__/useMergeRefs.test.tsx
@@ -1,0 +1,29 @@
+import { render } from "@testing-library/react";
+import * as React from "react";
+import { describe, expect, it, vi } from "vitest";
+
+import { useMergeRefs } from "../../../components";
+
+describe("useMergeRefs tests", () => {
+	it("should combine multiple refs of different types", () => {
+		const Dummy = React.forwardRef(function Dummy(_, ref) {
+			React.useImperativeHandle(ref, () => "refValue");
+			return null;
+		});
+		const refAsFunc = vi.fn();
+		const refAsObj = { current: undefined };
+		const Example: React.FC<{ visible: boolean }> = ({ visible }) => {
+			const ref = useMergeRefs([refAsObj, refAsFunc]);
+			return visible ? <Dummy ref={ref} /> : null;
+		};
+		const { rerender } = render(<Example visible />);
+		expect(refAsFunc).toHaveBeenCalledTimes(1);
+		expect(refAsFunc).toHaveBeenCalledWith("refValue");
+		expect(refAsObj.current).toBe("refValue");
+
+		rerender(<Example visible={false} />);
+		expect(refAsFunc).toHaveBeenCalledTimes(2);
+		expect(refAsFunc).toHaveBeenCalledWith(null);
+		expect(refAsObj.current).toBe(null);
+	});
+});

--- a/packages/ui-components/src/common/hooks/__tests__/useUniqueId.test.tsx
+++ b/packages/ui-components/src/common/hooks/__tests__/useUniqueId.test.tsx
@@ -2,7 +2,7 @@ import { renderHook } from "@testing-library/react";
 
 import { useUniqueId } from "../../../components";
 
-const regex = /[\w-_:]/;
+const regex = /^[\w-_:]+$/;
 
 describe("useUniqueId tests", () => {
 	it("should return two unique random numbers", () => {
@@ -32,7 +32,7 @@ describe("useUniqueId tests", () => {
 	it("should use the prefix that was given via object", () => {
 		const res1 = renderHook(() => useUniqueId({ prefix: "hello-" }));
 		expect(res1.result.current).toContain("hello");
-		expect(res1.result.current).toMatch(/hello-[\w-_:]/);
+		expect(res1.result.current).toMatch(/hello-[\w-_:]+$/);
 	});
 
 	it("should use the id and prefix that were given via object", () => {

--- a/packages/ui-components/src/common/hooks/__tests__/useUniqueId.test.tsx
+++ b/packages/ui-components/src/common/hooks/__tests__/useUniqueId.test.tsx
@@ -1,6 +1,6 @@
 import { renderHook } from "@testing-library/react";
 
-import useUniqueId from "../useUniqueId";
+import { useUniqueId } from "../../../components";
 
 const regex = /[\w-_:]/;
 

--- a/packages/ui-components/src/common/hooks/useMergeRefs.ts
+++ b/packages/ui-components/src/common/hooks/useMergeRefs.ts
@@ -37,5 +37,6 @@ export function useMergeRefs<T = any>(
 				}
 			});
 		};
-	}, [refs]);
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, refs);
 }

--- a/packages/ui-components/src/common/hooks/useMergeRefs.ts
+++ b/packages/ui-components/src/common/hooks/useMergeRefs.ts
@@ -1,0 +1,41 @@
+/**
+ * React utility to merge refs.
+ *
+ * When developing low level UI components, it is common to have to use a local
+ * ref but also support an external one using React.forwardRef. Natively, React
+ * does not offer a way to set two refs inside the ref property.
+ *
+ * @param Array of refs (object, function, etc.)
+ *
+ * @example
+ *
+ * const Example = React.forwardRef(function Example(props, ref) {
+ *   const localRef = React.useRef();
+ *   const mergedRef = useMergeRefs([localRef, ref]);
+ *
+ *   return <div ref={mergedRefs} />;
+ * });
+ *
+ */
+
+import { useMemo } from "react";
+export function useMergeRefs<T = any>(
+	refs: Array<
+		React.MutableRefObject<T> | React.LegacyRef<T> | undefined | null
+	>,
+): React.RefCallback<T> {
+	return useMemo(() => {
+		if (refs.every((ref) => ref == null)) {
+			return () => {};
+		}
+		return (value) => {
+			refs.forEach((ref) => {
+				if (typeof ref === "function") {
+					ref(value);
+				} else if (ref != null) {
+					(ref as React.MutableRefObject<T | null>).current = value;
+				}
+			});
+		};
+	}, [refs]);
+}

--- a/packages/ui-components/src/common/hooks/useMergeRefs.ts
+++ b/packages/ui-components/src/common/hooks/useMergeRefs.ts
@@ -11,7 +11,7 @@
  *
  * const Example = React.forwardRef(function Example(props, ref) {
  *   const localRef = React.useRef();
- *   const mergedRef = useMergeRefs([localRef, ref]);
+ *   const mergedRefs = useMergeRefs([localRef, ref]);
  *
  *   return <div ref={mergedRefs} />;
  * });

--- a/packages/ui-components/src/common/hooks/useUniqueId.ts
+++ b/packages/ui-components/src/common/hooks/useUniqueId.ts
@@ -40,7 +40,7 @@ export type UseUniqueIdOptions =
 			prefix?: string;
 	  };
 
-function useUniqueId(options?: UseUniqueIdOptions) {
+export function useUniqueId(options?: UseUniqueIdOptions) {
 	const generatedId = useId();
 
 	if (!options) {
@@ -60,5 +60,3 @@ function useUniqueId(options?: UseUniqueIdOptions) {
 		return `${prefix}${generatedId}`;
 	}
 }
-
-export default useUniqueId;

--- a/packages/ui-components/src/common/utilities.ts
+++ b/packages/ui-components/src/common/utilities.ts
@@ -112,34 +112,3 @@ export const getSpacing = (spacing: SpacingType): string => {
 
 	return spacingClass;
 };
-
-/**
- * React utility to merge refs.
- * When developing low level UI components, it is common to have to use a local
- * ref but also support an external one using React.forwardRef. Natively, React
- * does not offer a way to set two refs inside the ref property.
- * @param Array of refs (object, function, etc.)
- *
- * @example
- *
- * const Example = React.forwardRef(function Example(props, ref) {
- *   const localRef = React.useRef();
- *   return <div ref={mergeRefs([localRef, ref])} />;
- * });
- *
- */
-export function mergeRefs<T = any>(
-	refs: Array<
-		React.MutableRefObject<T> | React.LegacyRef<T> | undefined | null
-	>,
-): React.RefCallback<T> {
-	return (value) => {
-		refs.forEach((ref) => {
-			if (typeof ref === "function") {
-				ref(value);
-			} else if (ref != null) {
-				(ref as React.MutableRefObject<T | null>).current = value;
-			}
-		});
-	};
-}

--- a/packages/ui-components/src/components/Card/Card.tsx
+++ b/packages/ui-components/src/components/Card/Card.tsx
@@ -1,5 +1,5 @@
 import { CARD_CLASSNAME } from "../../common/constants";
-import useUniqueId from "../../common/hooks/useUniqueId";
+import { useUniqueId } from "..";
 import type { CardHeaderProps, CardProps } from "./CardTypes";
 import { getCardClasses } from "./utilities";
 

--- a/packages/ui-components/src/components/TextArea/TextArea.tsx
+++ b/packages/ui-components/src/components/TextArea/TextArea.tsx
@@ -2,8 +2,7 @@ import React, { useLayoutEffect, useRef, useState } from "react";
 
 import { TEXT_AREA_CLASSNAME } from "../../common/constants";
 import { useUncontrolled } from "../../common/hooks/useUncontrolled";
-import useUniqueId from "../../common/hooks/useUniqueId";
-import { mergeRefs } from "../../common/utilities";
+import { useMergeRefs, useUniqueId } from "..";
 import { LiveRegion } from "../private/LiveRegion/LiveRegion";
 import type { TextAreaProps } from "./TextAreaTypes";
 import { adjustLabelAndHelperText, getTextAreaClasses } from "./utilities";
@@ -39,7 +38,7 @@ export const TextArea = React.forwardRef<HTMLTextAreaElement, TextAreaProps>(
 		ref,
 	) => {
 		const textAreaRef = useRef<HTMLTextAreaElement>(null);
-		const mergedTextAreaRef = mergeRefs([ref, textAreaRef]);
+		const mergedTextAreaRef = useMergeRefs([ref, textAreaRef]);
 		const rightElementRef = useRef<HTMLDivElement>(null);
 		const textAreaHeightRef = useRef<number>(80);
 		const labelOffsetRef = useRef<number>(-25);

--- a/packages/ui-components/src/components/TextInput/TextInput.tsx
+++ b/packages/ui-components/src/components/TextInput/TextInput.tsx
@@ -1,7 +1,7 @@
 import React, { useLayoutEffect, useRef, useState } from "react";
 
 import { TEXT_INPUT_CLASSNAME } from "../../common/constants";
-import useUniqueId from "../../common/hooks/useUniqueId";
+import { useUniqueId } from "../";
 import { LiveRegion } from "../private/LiveRegion/LiveRegion";
 import type { TextInputProps } from "./TextInputTypes";
 import { getTextInputClasses } from "./utilities";

--- a/packages/ui-components/src/components/TextInput/TextInputMask.tsx
+++ b/packages/ui-components/src/components/TextInput/TextInputMask.tsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useRef, useState } from "react";
 
-import { mergeRefs } from "../../common/utilities";
-import { ButtonIcon, IconHide, IconShow, TextInput } from "..";
+import { ButtonIcon, IconHide, IconShow, TextInput, useMergeRefs } from "..";
 import { LiveRegion } from "../private/LiveRegion/LiveRegion";
 import type { TextInputMaskProps } from "./TextInputTypes";
 
@@ -44,7 +43,7 @@ export const TextInputMask = React.forwardRef<
 		const isMaskedRef = useRef(true);
 		const automaskTimerRef = useRef<number>();
 		const inputRef = useRef<HTMLInputElement>(null);
-		const mergedInputRef = mergeRefs([ref, inputRef]);
+		const mergedInputRef = useMergeRefs([ref, inputRef]);
 
 		const buttonLabel = masked ? "Show" : "Hide";
 

--- a/packages/ui-components/src/components/index.ts
+++ b/packages/ui-components/src/components/index.ts
@@ -1,5 +1,7 @@
 import "./index.css";
 
+import { useMergeRefs } from "../common/hooks/useMergeRefs";
+import { useUniqueId } from "../common/hooks/useUniqueId";
 import { Anchor } from "./Anchor/Anchor";
 import { Button } from "./Button/Button";
 import { ButtonIcon } from "./Button/ButtonIcon";
@@ -54,4 +56,6 @@ export {
 	TextInput,
 	TextInputMask,
 	Toggle,
+	useMergeRefs,
+	useUniqueId,
 };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new test suite for the `useMergeRefs` hook to ensure proper functionality.
  - Added `useMergeRefs` and `useUniqueId` hooks to the component library exports for wider use.

- **Refactor**
  - Updated components to use the `useMergeRefs` hook for merging refs, enhancing code maintainability.
  - Changed the import locations for `useUniqueId` to reflect updated code organization.

- **Bug Fixes**
  - Removed deprecated `mergeRefs` utility to prevent potential conflicts with the new `useMergeRefs` hook.

- **Documentation**
  - Adjusted documentation to align with the removal of `mergeRefs` and the introduction of `useMergeRefs` and `useUniqueId` hooks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->