### PR TITLE
feat(TextArea): adding "helperTextOnFocus" prop

### DIFF
--- a/packages/documentation/src/stories/TextArea.stories.tsx
+++ b/packages/documentation/src/stories/TextArea.stories.tsx
@@ -70,6 +70,7 @@ export const Basic: Story = {
 				<div className="flex flex-wrap gap-2">
 					<TextArea {...args} />
 					<TextArea {...args} />
+					<TextArea {...args} helperTextOnFocus />
 				</div>
 			</form>
 		</div>

--- a/packages/ui-components/src/components/TextArea/TextArea.tsx
+++ b/packages/ui-components/src/components/TextArea/TextArea.tsx
@@ -29,9 +29,12 @@ export const TextArea = React.forwardRef<HTMLTextAreaElement, TextAreaProps>(
 			labelId,
 
 			helperText = "",
+			helperTextOnFocus = false,
 
 			rightElement,
 			onChange,
+			onFocus,
+			onBlur,
 
 			...extraProps
 		},
@@ -49,6 +52,9 @@ export const TextArea = React.forwardRef<HTMLTextAreaElement, TextAreaProps>(
 		const textAreaId = useUniqueId({ id, prefix: `${TEXT_AREA_CLASSNAME}-` });
 
 		const [textAreaPaddingRight, setTextAreaPaddingRight] = useState(0);
+		const [showHelperText, setShowHelperText] = useState(
+			Boolean(!helperTextOnFocus && helperText),
+		);
 
 		const liveErrorMessage = `${name} error, ${helperText}`;
 		const textTextAreaClassName = getTextAreaClasses({
@@ -82,6 +88,20 @@ export const TextArea = React.forwardRef<HTMLTextAreaElement, TextAreaProps>(
 
 		const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
 			setValue(e.target.value);
+		};
+
+		const handleFocus = (e: React.FocusEvent<HTMLTextAreaElement, Element>) => {
+			if (helperTextOnFocus && helperText) {
+				setShowHelperText(true);
+			}
+			onFocus && onFocus(e);
+		};
+
+		const handleBlur = (e: React.FocusEvent<HTMLTextAreaElement, Element>) => {
+			if (helperTextOnFocus && helperText && !userInput) {
+				setShowHelperText(false);
+			}
+			onBlur && onBlur(e);
 		};
 
 		/**
@@ -200,6 +220,8 @@ export const TextArea = React.forwardRef<HTMLTextAreaElement, TextAreaProps>(
 						!raw && { style: { paddingRight: textAreaPaddingRight } })}
 					value={userInput}
 					onChange={handleChange}
+					onFocus={handleFocus}
+					onBlur={handleBlur}
 					{...extraProps}
 				/>
 				{!raw && (
@@ -213,7 +235,7 @@ export const TextArea = React.forwardRef<HTMLTextAreaElement, TextAreaProps>(
 					</label>
 				)}
 
-				{helperText && (
+				{showHelperText && (
 					<div
 						ref={helperTextRef}
 						id={`${textAreaId}-helper`}

--- a/packages/ui-components/src/components/TextArea/TextAreaTypes.d.ts
+++ b/packages/ui-components/src/components/TextArea/TextAreaTypes.d.ts
@@ -3,6 +3,7 @@ export type TextAreaProps = {
 	name: string;
 	labelId?: string;
 	helperText?: string;
+	helperTextOnFocus?: boolean;
 	error?: boolean;
 	focusKind?: "dark" | "light";
 	borderKind?: "dark" | "light";

--- a/packages/ui-components/src/components/TextArea/__tests__/TextArea.test.tsx
+++ b/packages/ui-components/src/components/TextArea/__tests__/TextArea.test.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 
-import { act, render, screen } from "@testing-library/react";
+import { act, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import { expectToHaveClasses } from "../../../common/__tests__/helpers";
@@ -96,6 +96,45 @@ describe("TextArea modifiers", () => {
 			TEXT_AREA_CONTROL_RIGHT_CLASSNAME,
 		);
 	});
+
+	it("should render a text area with a helper text", async () => {
+		render(
+			<TextArea
+				label="toto"
+				name="toto"
+				helperText="helper text"
+				data-testid="txtnpt-1"
+			/>,
+		);
+		const helperText = await screen.findByText("helper text");
+		expect(helperText.className).toContain("av-text-area-helper-text");
+	});
+
+	it("should render a text area with a helper text on focus only", async () => {
+		const user = userEvent.setup();
+		render(
+			<TextArea
+				label="toto"
+				name="toto"
+				helperText="helper text"
+				helperTextOnFocus
+				data-testid="txtnpt-1"
+			/>,
+		);
+
+		await waitFor(() => {
+			expect(screen.queryByText("helper text")).not.toBeInTheDocument();
+		});
+		const input = await screen.findByTestId("txtnpt-1");
+		await user.type(input, "aa");
+		expect(screen.queryByText("helper text")).toBeInTheDocument();
+
+		await user.clear(input);
+		await user.tab();
+		await waitFor(() => {
+			expect(screen.queryByText("helper text")).not.toBeInTheDocument();
+		});
+	});
 });
 
 describe("TextArea methods", () => {
@@ -122,6 +161,49 @@ describe("TextArea methods", () => {
 		await user.type(input, "aa");
 
 		expect(spyOnChange).toHaveBeenCalledTimes(2);
+	});
+
+	it("should honor the onFocus prop", async () => {
+		const events = {
+			onFocus: () => {},
+		};
+		const spyOnFocus = vi.spyOn(events, "onFocus");
+		const user = userEvent.setup();
+		render(
+			<TextArea
+				// @ts-ignore
+				onFocus={spyOnFocus}
+				label="hello world"
+				name="toto"
+				data-testid="txtnpt-1"
+			/>,
+		);
+		const input = await screen.findByTestId("txtnpt-1");
+		await user.type(input, "aa");
+
+		expect(spyOnFocus).toHaveBeenCalledTimes(1);
+	});
+
+	it("should honor the onBlur prop", async () => {
+		const events = {
+			onBlur: () => {},
+		};
+		const spyOnBlur = vi.spyOn(events, "onBlur");
+		const user = userEvent.setup();
+		render(
+			<TextArea
+				// @ts-ignore
+				onBlur={spyOnBlur}
+				label="hello world"
+				name="toto"
+				data-testid="txtnpt-1"
+			/>,
+		);
+		const input = await screen.findByTestId("txtnpt-1");
+		await user.type(input, "aa");
+		await user.tab();
+
+		expect(spyOnBlur).toHaveBeenCalledTimes(1);
 	});
 });
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a `helperTextOnFocus` feature for `TextArea` components, displaying helper text when the field is focused.

- **Documentation**
  - Updated `TextArea` component documentation to include examples with the new `helperTextOnFocus` property.

- **Tests**
  - Added tests to verify the behavior of the `helperTextOnFocus` feature in `TextArea` components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->