### PR TITLE
feat(Table): adding sticky header support

### DIFF
--- a/packages/documentation/src/stories/Table.stories.tsx
+++ b/packages/documentation/src/stories/Table.stories.tsx
@@ -156,3 +156,110 @@ export const WithAction: Story = {
 		);
 	},
 };
+
+export const WithStickyHeader: Story = {
+	render: function Render(args) {
+		const data = [
+			{
+				id: 1,
+				timestamp: "10/16/2023 08:46 PM EDT",
+				character: "Who plays Paul Atreides?",
+				actor: "Timothée Chalamet",
+			},
+			{
+				id: 2,
+				timestamp: "10/16/2023 08:55 PM EDT",
+				character: "What about Lady Jessica?",
+				actor: "Rebecca Ferguson",
+			},
+			{
+				id: 3,
+				timestamp: "10/16/2023 08:59 PM EDT",
+				character: "And Duncan Idaho?",
+				actor: "Jason Momoa",
+			},
+			{
+				id: 4,
+				timestamp: "10/16/2023 08:59 PM EDT",
+				character: "And Duncan Idaho?",
+				actor: "Jason Momoa",
+			},
+			{
+				id: 5,
+				timestamp: "10/16/2023 08:59 PM EDT",
+				character: "And Duncan Idaho?",
+				actor: "Jason Momoa",
+			},
+			{
+				id: 6,
+				timestamp: "10/16/2023 08:59 PM EDT",
+				character: "And Duncan Idaho?",
+				actor: "Jason Momoa",
+			},
+			{
+				id: 7,
+				timestamp: "10/16/2023 08:59 PM EDT",
+				character: "And Duncan Idaho?",
+				actor: "Jason Momoa",
+			},
+		];
+
+		return (
+			<div className="min-h-10 bgg-slate-500 p-11">
+				<div className="flex flex-wrap gap-2">
+					<Table maxHeight="250px" stickyHeader {...args}>
+						<TableHead className="uppercase">
+							<TableRow>
+								<TableCell scope="col">Date</TableCell>
+								<TableCell scope="col">First message</TableCell>
+								<TableCell className="text-right" scope="col">
+									Actions
+								</TableCell>
+							</TableRow>
+						</TableHead>
+
+						<TableBody>
+							{data.map((row, idx) => {
+								return (
+									<TableRow key={`${row.id}-${idx}`}>
+										<TableCell
+											component="th"
+											scope="row"
+											className="text-gray-400"
+										>
+											{row.timestamp}
+										</TableCell>
+										<TableCell>{row.character}</TableCell>
+
+										<TableCell>
+											<div className="flex justify-end gap-2">
+												<ButtonIcon
+													noBorder
+													label="Restore chat"
+													kind="light"
+													onClick={() => {}}
+												>
+													<IconRestore className="h-3 w-3" />
+												</ButtonIcon>
+												<ButtonIcon
+													noBorder
+													label="Delete chat"
+													kind="light"
+													onClick={() => {}}
+												>
+													<div className="text-red-400">
+														<IconDelete className="h-3 w-3" />
+													</div>
+												</ButtonIcon>
+											</div>
+										</TableCell>
+									</TableRow>
+								);
+							})}
+						</TableBody>
+					</Table>
+				</div>
+			</div>
+		);
+	},
+};

--- a/packages/ui-components/src/components/Table/Table.tsx
+++ b/packages/ui-components/src/components/Table/Table.tsx
@@ -31,7 +31,6 @@ export const Table = ({
 		kind,
 		className,
 		stickyHeader,
-		maxHeight,
 	});
 	return (
 		<TableContext.Provider value={{ kind, stickyHeader }}>

--- a/packages/ui-components/src/components/Table/Table.tsx
+++ b/packages/ui-components/src/components/Table/Table.tsx
@@ -13,6 +13,7 @@ import {
 	CELL_WRAPPER_HEAD,
 	getTableCellClasses,
 	getTableClasses,
+	getTableHeadClasses,
 	getTableRowClasses,
 } from "./utilities";
 
@@ -22,12 +23,24 @@ export const Table = ({
 	caption,
 	summary,
 	className,
+	maxHeight,
+	stickyHeader,
 	...otherProps
 }: TableProps) => {
-	const tableClass = getTableClasses({ kind, className });
+	const tableClass = getTableClasses({
+		kind,
+		className,
+		stickyHeader,
+		maxHeight,
+	});
 	return (
-		<TableContext.Provider value={{ kind }}>
-			<div className={tableClass.wrapper}>
+		<TableContext.Provider value={{ kind, stickyHeader }}>
+			<div
+				className={tableClass.wrapper}
+				{...(maxHeight && {
+					style: { maxHeight },
+				})}
+			>
 				<table className={tableClass.table} summary={summary} {...otherProps}>
 					{caption && (
 						<caption className={tableClass.caption}>{caption}</caption>
@@ -39,10 +52,22 @@ export const Table = ({
 	);
 };
 
-export const TableHead = ({ children, ...otherProps }: TableHeadProps) => {
+export const TableHead = ({
+	children,
+	className,
+	...otherProps
+}: TableHeadProps) => {
 	const context = useContext(TableContext);
 	context.cellWrapper = CELL_WRAPPER_HEAD;
-	return <thead {...otherProps}>{children}</thead>;
+	const tableHeadClass = getTableHeadClasses({
+		className,
+		stickyHeader: context.stickyHeader,
+	});
+	return (
+		<thead className={tableHeadClass} {...otherProps}>
+			{children}
+		</thead>
+	);
 };
 
 export const TableBody = ({ children, ...otherProps }: TableBodyProps) => {

--- a/packages/ui-components/src/components/Table/TableContext.ts
+++ b/packages/ui-components/src/components/Table/TableContext.ts
@@ -3,7 +3,9 @@ import React from "react";
 export const TableContext = React.createContext<{
 	kind: "light" | "dark";
 	cellWrapper?: "thead" | "tbody";
+	stickyHeader?: boolean;
 }>({
 	kind: "light",
 	cellWrapper: "thead",
+	stickyHeader: false,
 });

--- a/packages/ui-components/src/components/Table/TableTypes.d.ts
+++ b/packages/ui-components/src/components/Table/TableTypes.d.ts
@@ -12,6 +12,18 @@ export type TableProps = {
 	 * read out loud by screen readers to represent the table.
 	 */
 	summary?: string;
+	/**
+	 * The max height of the table. It follows the CSS max-height property.
+	 * Note: It is required to configure 'maxHeight' prop for the prop
+	 * 'stickyHeader' to work.
+	 */
+	maxHeight?: string;
+	/**
+	 * If true, the table header will be sticky.
+	 * Note: It is required to configure 'maxHeight' prop for the prop
+	 * 'stickyHeader' to work.
+	 */
+	stickyHeader?: boolean;
 } & React.HTMLAttributes<HTMLTableElement>;
 
 export type TableRowProps = React.HTMLAttributes<HTMLTableRowElement>;

--- a/packages/ui-components/src/components/Table/__tests__/Table.test.tsx
+++ b/packages/ui-components/src/components/Table/__tests__/Table.test.tsx
@@ -1,6 +1,9 @@
 import { render, screen } from "@testing-library/react";
 
-import { expectToHaveClasses } from "../../../common/__tests__/helpers";
+import {
+	expectToHaveClasses,
+	expectToHaveStyles,
+} from "../../../common/__tests__/helpers";
 import { Table, TableBody, TableCell, TableHead, TableRow } from "../..";
 
 describe("Table (exceptions)", () => {
@@ -154,6 +157,92 @@ describe("Table classes", () => {
 				"last:border-0",
 				"odd:bg-table-light-odd",
 				"even:bg-table-light-even",
+			]);
+		}
+		if (tableCellHead) {
+			expectToHaveClasses(tableCellHead, ["px-4", "py-3"]);
+		}
+		if (tableCellBody) {
+			expectToHaveClasses(tableCellBody, ["p-4"]);
+		}
+	});
+
+	it("should render a table with a sticky header", async () => {
+		render(
+			<Table
+				data-testid="table"
+				caption="the caption"
+				maxHeight="100px"
+				stickyHeader
+			>
+				<TableHead data-testid="table-head">
+					<TableRow data-testid="table-row-head">
+						<TableCell data-testid="table-cell-head">the header</TableCell>
+					</TableRow>
+				</TableHead>
+				<TableBody>
+					<TableRow data-testid="table-row-body">
+						<TableCell data-testid="table-cell-body">the body</TableCell>
+					</TableRow>
+				</TableBody>
+			</Table>,
+		);
+		const table = await screen.findByTestId("table");
+		const wrapper = table.parentElement;
+		const caption = table.querySelector("caption");
+		const tableHead = await screen.findByTestId("table-head");
+		const tableRowHead = await screen.findByTestId("table-row-head");
+		const tableRowBody = await screen.findByTestId("table-row-body");
+		const tableCellHead = await screen.findByTestId("table-cell-head");
+		const tableCellBody = await screen.findByTestId("table-cell-body");
+
+		expect(table).toBeInTheDocument();
+		expect(table.tagName).toBe("TABLE");
+
+		expectToHaveClasses(table, [
+			"w-full",
+			"text-left",
+			"text-sm",
+			"text-copy-light",
+		]);
+		if (wrapper) {
+			expectToHaveClasses(wrapper, [
+				"relative",
+				"w-full",
+				"overflow-y-scroll",
+				"rounded-lg",
+				"shadow-md",
+				"bg-surface-dark",
+				"text-copy-light",
+			]);
+			expectToHaveStyles(wrapper, { "max-height": "100px" });
+		}
+		if (caption) {
+			expectToHaveClasses(caption, [
+				"py-2",
+				"text-sm",
+				"font-bold",
+				"text-copy-light",
+			]);
+		}
+		if (tableHead) {
+			expectToHaveClasses(tableHead, ["sticky", "top-0", "z-10"]);
+		}
+		if (tableRowHead) {
+			expectToHaveClasses(tableRowHead, [
+				"border-b",
+				"last:border-0",
+				"border-table-dark",
+				"bg-table-dark",
+			]);
+		}
+		if (tableRowBody) {
+			expectToHaveClasses(tableRowBody, [
+				"border-b",
+				"last:border-0",
+				"border-table-dark",
+				"odd:bg-table-dark-odd",
+				"even:bg-table-dark-even",
 			]);
 		}
 		if (tableCellHead) {

--- a/packages/ui-components/src/components/Table/utilities.ts
+++ b/packages/ui-components/src/components/Table/utilities.ts
@@ -7,16 +7,13 @@ export const getTableClasses = ({
 	kind,
 	className,
 	stickyHeader,
-	maxHeight,
 }: {
 	kind: string;
 	className?: string;
 	stickyHeader?: boolean;
-	maxHeight?: string;
 }) => {
 	return {
 		wrapper: clsx("relative w-full rounded-lg shadow-md", {
-			[`max-h-[${maxHeight}]`]: maxHeight,
 			"overflow-x-auto": !stickyHeader,
 			"overflow-y-scroll": stickyHeader,
 			"bg-surface-dark text-copy-light": kind === "dark",

--- a/packages/ui-components/src/components/Table/utilities.ts
+++ b/packages/ui-components/src/components/Table/utilities.ts
@@ -6,12 +6,19 @@ export const CELL_WRAPPER_BODY = "tbody";
 export const getTableClasses = ({
 	kind,
 	className,
+	stickyHeader,
+	maxHeight,
 }: {
 	kind: string;
 	className?: string;
+	stickyHeader?: boolean;
+	maxHeight?: string;
 }) => {
 	return {
-		wrapper: clsx("relative w-full overflow-x-auto rounded-lg shadow-md", {
+		wrapper: clsx("relative w-full rounded-lg shadow-md", {
+			[`max-h-[${maxHeight}]`]: maxHeight,
+			"overflow-x-auto": !stickyHeader,
+			"overflow-y-scroll": stickyHeader,
 			"bg-surface-dark text-copy-light": kind === "dark",
 			"bg-surface-light text-copy-dark": kind === "light",
 		}),
@@ -24,6 +31,18 @@ export const getTableClasses = ({
 			"text-copy-dark": kind === "light",
 		}),
 	};
+};
+
+export const getTableHeadClasses = ({
+	className,
+	stickyHeader,
+}: {
+	className?: string;
+	stickyHeader?: boolean;
+}) => {
+	return clsx(className, {
+		"sticky top-0 z-10": stickyHeader,
+	});
 };
 
 export const getTableRowClasses = ({


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced `WithStickyHeader` story to demonstrate tables with sticky headers.
  - Table components now support `maxHeight` and `stickyHeader` properties for enhanced usability.

- **Enhancements**
  - Updated `TableHead` to accept a `className` prop and apply sticky header styles.

- **Documentation**
  - Documented usage of new `maxHeight` and `stickyHeader` props in `TableProps`.

- **Tests**
  - Added tests to verify the correct rendering of tables with sticky headers.

- **Refactor**
  - Enhanced `TableContext` to include a new `stickyHeader` boolean property.
  - Refined utility functions to handle new styling conditions for sticky headers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->