### PR TITLE
fix(Icon): missing "decorative" prop from Icons types

### DIFF
--- a/packages/ui-components/src/components/Icons/IconsTypes.d.ts
+++ b/packages/ui-components/src/components/Icons/IconsTypes.d.ts
@@ -3,4 +3,5 @@ import { SpacingType } from "../../common";
 export interface IconsProps
 	extends Omit<React.SVGAttributes<SVGElement>, "spacing"> {
 	spacing?: SpacingType;
+	decorative?: boolean;
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced an optional `decorative` property for icons to enhance accessibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->