### PR TITLE
feat(ButtonIcon): adding support for label on the right

### DIFF
--- a/packages/documentation/src/stories/ButtonIcon.stories.tsx
+++ b/packages/documentation/src/stories/ButtonIcon.stories.tsx
@@ -69,3 +69,22 @@ export const Basic: Story = {
 		</div>
 	),
 };
+
+export const WithLabel: Story = {
+	render: (args) => (
+		<div className="flex flex-wrap gap-2">
+			<ButtonIcon labelRight="Settings" {...args}>
+				<IconSettings decorative />
+			</ButtonIcon>
+			<ButtonIcon labelRight="Settings" {...args}>
+				<IconSettings decorative />
+			</ButtonIcon>
+			<ButtonIcon labelRight="Edit" {...args}>
+				<IconEdit decorative className="h-3 w-3" />
+			</ButtonIcon>
+			<ButtonIcon labelRight="Edit" {...args}>
+				<IconEdit decorative />
+			</ButtonIcon>
+		</div>
+	),
+};

--- a/packages/ui-components/src/components/Button/ButtonIcon.tsx
+++ b/packages/ui-components/src/components/Button/ButtonIcon.tsx
@@ -19,6 +19,7 @@ export const ButtonIcon = React.forwardRef<HTMLButtonElement, ButtonIconProps>(
 			"aria-label": ariaLabel,
 			label,
 			size = "medium",
+			labelRight,
 
 			...otherProps
 		},
@@ -34,6 +35,7 @@ export const ButtonIcon = React.forwardRef<HTMLButtonElement, ButtonIconProps>(
 			className,
 			noBorder,
 			size,
+			labelRight,
 		});
 
 		return (
@@ -47,6 +49,7 @@ export const ButtonIcon = React.forwardRef<HTMLButtonElement, ButtonIconProps>(
 				{...otherProps}
 			>
 				{children}
+				{labelRight && <span className="pl-2">{labelRight}</span>}
 			</button>
 		);
 	},

--- a/packages/ui-components/src/components/Button/ButtonTypes.d.ts
+++ b/packages/ui-components/src/components/Button/ButtonTypes.d.ts
@@ -6,6 +6,7 @@ export type CommonButtonProps = {
 	className?: string;
 	raw?: boolean;
 	noBorder?: boolean;
+	labelRight?: string;
 };
 
 export type ButtonProps = {

--- a/packages/ui-components/src/components/Button/__tests__/ButtonIcon.test.tsx
+++ b/packages/ui-components/src/components/Button/__tests__/ButtonIcon.test.tsx
@@ -96,6 +96,24 @@ describe("ButtonIcon modifiers", () => {
 		expectToHaveClasses(button, ["h-6", "w-6", "p-0"]);
 	});
 
+	it("should render a size small button with a label on the right", async () => {
+		render(
+			<ButtonIcon size="small" labelRight="Settings">
+				<IconSettings decorative />
+			</ButtonIcon>,
+		);
+		const button = await screen.findByRole("button");
+		const label = await screen.findByText("Settings");
+		expect(label).toBeDefined();
+		expectToHaveClasses(button, [
+			"h-6",
+			"pl-2",
+			"pr-4",
+			"text-sm",
+			"font-medium",
+		]);
+	});
+
 	it("should render a size medium button", async () => {
 		render(
 			<ButtonIcon size="medium">
@@ -106,6 +124,24 @@ describe("ButtonIcon modifiers", () => {
 		expectToHaveClasses(button, ["h-8", "w-8", "p-1"]);
 	});
 
+	it("should render a size medium button with a label on the right", async () => {
+		render(
+			<ButtonIcon size="medium" labelRight="Settings">
+				<IconSettings decorative />
+			</ButtonIcon>,
+		);
+		const button = await screen.findByRole("button");
+		const label = await screen.findByText("Settings");
+		expect(label).toBeDefined();
+		expectToHaveClasses(button, [
+			"h-8",
+			"pl-2",
+			"pr-4",
+			"text-base",
+			"font-medium",
+		]);
+	});
+
 	it("should render a size large button", async () => {
 		render(
 			<ButtonIcon size="large">
@@ -113,6 +149,24 @@ describe("ButtonIcon modifiers", () => {
 			</ButtonIcon>,
 		);
 		const button = await screen.findByRole("button");
-		expectToHaveClasses(button, ["h-10", "w-10", "p-2"]);
+		expectToHaveClasses(button, ["h-12", "w-12", "p-2"]);
+	});
+
+	it("should render a size large button with a label on the right", async () => {
+		render(
+			<ButtonIcon size="large" labelRight="Settings">
+				<IconSettings decorative />
+			</ButtonIcon>,
+		);
+		const button = await screen.findByRole("button");
+		const label = await screen.findByText("Settings");
+		expect(label).toBeDefined();
+		expectToHaveClasses(button, [
+			"h-12",
+			"pl-2",
+			"pr-4",
+			"text-lg",
+			"font-medium",
+		]);
 	});
 });

--- a/packages/ui-components/src/components/Button/utilities.ts
+++ b/packages/ui-components/src/components/Button/utilities.ts
@@ -8,25 +8,29 @@ export const TYPE_LINK = "link";
 
 type getButtonClassesProps = {
 	type: typeof TYPE_BUTTON | typeof TYPE_ICON | typeof TYPE_LINK;
-	className?: string;
 	raw: boolean;
 	kind: string;
 	focus: string;
 	disabled: boolean;
 	fullWidth: boolean;
-	slim?: boolean;
 	size: string;
 	noBorder: boolean;
+
+	className?: string;
+	slim?: boolean;
+	labelRight?: string;
 };
 
 const getButtonSizesClasses = ({
 	type,
 	slim,
 	size,
+	labelRight,
 }: {
 	type: string;
-	slim?: boolean;
 	size: string;
+	slim?: boolean;
+	labelRight?: string;
 }) => {
 	const smallClasses = "text-sm font-medium max-h-8 py-0";
 	const mediumClasses = "text-base font-medium max-h-9 py-1";
@@ -49,9 +53,17 @@ const getButtonSizesClasses = ({
 
 		case TYPE_ICON:
 			return clsx("inline-flex items-center justify-center", {
-				"h-6 w-6 p-0": size === "small" || slim,
-				"h-8 w-8 p-1": size === "medium" && !slim,
-				"h-10 w-10 p-2": size === "large" && !slim,
+				"h-6 w-6 p-0": (size === "small" || slim) && !labelRight,
+				"h-6 pl-2 pr-4 text-sm font-medium":
+					(size === "small" || slim) && labelRight,
+
+				"h-8 w-8 p-1": size === "medium" && !slim && !labelRight,
+				"h-8 pl-2 pr-4 text-base font-medium":
+					size === "medium" && !slim && labelRight,
+
+				"h-12 w-12 p-2": size === "large" && !slim && !labelRight,
+				"h-12 pl-2 pr-4 text-lg font-medium":
+					size === "large" && !slim && labelRight,
 			});
 	}
 };
@@ -113,6 +125,7 @@ export const getButtonClasses = ({
 	slim,
 	size,
 	noBorder,
+	labelRight,
 }: getButtonClassesProps) => {
 	return raw
 		? clsx(BUTTON_CLASSNAME, className)
@@ -120,7 +133,7 @@ export const getButtonClasses = ({
 				BUTTON_CLASSNAME,
 				className,
 				getButtonBaseClasses({ kind }),
-				getButtonSizesClasses({ type, slim, size }),
+				getButtonSizesClasses({ type, slim, size, labelRight }),
 				getButtonBorderClasses({ kind, noBorder }),
 				getButtonFocusClasses({ focus }),
 				getButtonHoverClasses({ kind, disabled }),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced `WithLabel` story for ButtonIcon components, showcasing usage with labels and icons.

- **Enhancements**
  - Added `labelRight` prop to ButtonIcon component for displaying labels on the right side.

- **Documentation**
  - Updated ButtonIcon documentation with examples of labeled icons.

- **Tests**
  - Added new tests for ButtonIcon with `labelRight` prop to ensure correct rendering.

- **Refactor**
  - Enhanced button utility functions to support the new `labelRight` property.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->