### PR TITLE
feat(Panel): adding support for "footer" prop and "messagebox" kind

### DIFF
--- a/packages/documentation/src/stories/Menu.stories.tsx
+++ b/packages/documentation/src/stories/Menu.stories.tsx
@@ -10,7 +10,9 @@ import {
 	Menu,
 	MenuItem,
 	MenuSeparator,
+	Panel,
 } from "@versini/ui-components";
+import { useState } from "react";
 
 const meta: Meta<typeof Menu> = {
 	component: Menu,
@@ -79,18 +81,68 @@ export const WithIcons: Story = {
 					<MenuItem label="Statistics" icon={<IconChart decorative />} />
 					<MenuItem label="History" icon={<IconHistory decorative />} />
 					<MenuItem label="About" icon={<IconInfo decorative />} />
-					<MenuSeparator />
-					<MenuItem
-						label="Log out"
-						icon={
-							<div className="text-red-700">
-								<IconBack decorative monotone />
-							</div>
-						}
-					/>
 				</Menu>
 				<Button size="small">Button</Button>
 			</div>
+		);
+	},
+};
+
+export const WithMessageBox: Story = {
+	args: {},
+
+	render: function Render(args) {
+		const [showMessage, setShowMessage] = useState(false);
+		const handleMenuLogout = () => {
+			setShowMessage(!showMessage);
+		};
+		const onLogout = () => {
+			// console.log("==> logout!");
+			setShowMessage(!showMessage);
+		};
+		const onCancel = () => {
+			// console.log("==> cancel logout...");
+			setShowMessage(!showMessage);
+		};
+		return (
+			<>
+				<Panel
+					kind="messagebox"
+					open={showMessage}
+					onOpenChange={setShowMessage}
+					title="Log out"
+					footer={
+						<div className="flex flex-row-reverse gap-2">
+							<Button onClick={onLogout}>Log out</Button>
+							<Button kind="light" onClick={onCancel}>
+								Cancel
+							</Button>
+						</div>
+					}
+				>
+					<p>Are you sure you want to log out?</p>
+				</Panel>
+				<div className="min-h-10 flex flex-wrap gap-2 bg-slate-500 p-11">
+					<Button size="small">Button</Button>
+					<Menu icon={<IconSettings />} {...args}>
+						<MenuItem label="Profile" icon={<IconProfile decorative />} />
+						<MenuItem label="Statistics" icon={<IconChart decorative />} />
+						<MenuItem label="History" icon={<IconHistory decorative />} />
+						<MenuItem label="About" icon={<IconInfo decorative />} />
+						<MenuSeparator />
+						<MenuItem
+							onClick={handleMenuLogout}
+							label="Log out"
+							icon={
+								<div className="text-red-700">
+									<IconBack decorative monotone />
+								</div>
+							}
+						/>
+					</Menu>
+					<Button size="small">Button</Button>
+				</div>
+			</>
 		);
 	},
 };

--- a/packages/documentation/src/stories/Panel.stories.tsx
+++ b/packages/documentation/src/stories/Panel.stories.tsx
@@ -1,6 +1,6 @@
 import { useArgs } from "@storybook/preview-api";
 import type { Meta, StoryObj } from "@storybook/react";
-import { Panel } from "@versini/ui-components";
+import { Button, Panel } from "@versini/ui-components";
 
 const meta: Meta<typeof Panel> = {
 	component: Panel,
@@ -12,10 +12,15 @@ const meta: Meta<typeof Panel> = {
 		title: "Panel Title",
 		children: "Panel Content",
 		borderKind: "light",
+		kind: "panel",
 	},
 	argTypes: {
 		borderKind: {
 			options: ["dark", "light"],
+			control: { type: "radio" },
+		},
+		kind: {
+			options: ["panel", "messagebox"],
 			control: { type: "radio" },
 		},
 	},
@@ -40,6 +45,18 @@ export const Basic: Story = {
 		const onOpenChange = () => {
 			updateArgs({ open: !open });
 		};
-		return <Panel open={open} onOpenChange={onOpenChange} {...args} />;
+		return (
+			<Panel
+				open={open}
+				onOpenChange={onOpenChange}
+				footer={
+					<div className="flex flex-row-reverse gap-2">
+						<Button noBorder>Log out</Button>
+						<Button kind="light">Cancel</Button>
+					</div>
+				}
+				{...args}
+			/>
+		);
 	},
 };

--- a/packages/ui-components/src/common/constants.ts
+++ b/packages/ui-components/src/common/constants.ts
@@ -17,9 +17,13 @@ export const FLEXGRID_CLASSNAME = "av-flexgrid";
 export const FLEXGRID_ITEM_CLASSNAME = "av-flexgrid-item";
 
 export const CARD_CLASSNAME = "av-card";
+
 export const SPINNER_CLASSNAME = "av-spinner";
 
 export const TOGGLE_CLASSNAME = "av-toggle";
+
+export const PANEL_CLASSNAME = "av-panel";
+export const MESSSAGEBOX_CLASSNAME = "av-messagebox";
 
 export const FLEXGRID_MAX_COLUMNS = 12;
 export const FLEXGRID_GAP_RATIO = 0.25;

--- a/packages/ui-components/src/common/constants.ts
+++ b/packages/ui-components/src/common/constants.ts
@@ -23,7 +23,7 @@ export const SPINNER_CLASSNAME = "av-spinner";
 export const TOGGLE_CLASSNAME = "av-toggle";
 
 export const PANEL_CLASSNAME = "av-panel";
-export const MESSSAGEBOX_CLASSNAME = "av-messagebox";
+export const MESSAGEBOX_CLASSNAME = "av-messagebox";
 
 export const FLEXGRID_MAX_COLUMNS = 12;
 export const FLEXGRID_GAP_RATIO = 0.25;

--- a/packages/ui-components/src/components/Panel/Panel.tsx
+++ b/packages/ui-components/src/components/Panel/Panel.tsx
@@ -1,4 +1,3 @@
-import clsx from "clsx";
 import { useEffect, useRef } from "react";
 
 import { IconClose } from "../";
@@ -10,22 +9,19 @@ import {
 	ModalHeading,
 } from "../private/Modal/Modal";
 import type { PanelProps } from "./PanelTypes";
+import { getPanelClassName, TYPE_PANEL } from "./utilities";
 
 export const Panel = ({
 	open,
 	onOpenChange,
 	title,
 	children,
+	footer,
 	borderKind = "light",
+	kind = TYPE_PANEL,
 }: PanelProps) => {
 	const originalTitleRef = useRef("");
-	const mainClass = clsx(
-		"bg-surface-medium flex h-full min-h-[95%] w-full flex-col sm:h-auto sm:min-h-[10rem] sm:w-[95%] sm:rounded-lg md:max-w-2xl",
-		{
-			"sm:border-2 sm:border-border-dark": borderKind === "dark",
-			"sm:border-2 sm:border-border-light": borderKind === "light",
-		},
-	);
+	const panelClassName = getPanelClassName({ kind, borderKind });
 
 	/**
 	 * If the panel is opened, set the document
@@ -46,7 +42,7 @@ export const Panel = ({
 
 	return (
 		<Modal open={open} onOpenChange={onOpenChange}>
-			<ModalContent className={mainClass}>
+			<ModalContent className={panelClassName.main}>
 				<ModalHeading className="flex flex-row-reverse justify-between p-4 text-xl font-bold">
 					<ModalClose>
 						<IconClose />
@@ -54,9 +50,11 @@ export const Panel = ({
 					<div>{title}</div>
 				</ModalHeading>
 
-				<ModalDescription className="flex flex-grow flex-col p-2 sm:p-4">
+				<ModalDescription className={panelClassName.content}>
 					{children}
 				</ModalDescription>
+
+				{footer && <div className={panelClassName.content}>{footer}</div>}
 			</ModalContent>
 		</Modal>
 	);

--- a/packages/ui-components/src/components/Panel/PanelTypes.d.ts
+++ b/packages/ui-components/src/components/Panel/PanelTypes.d.ts
@@ -1,7 +1,11 @@
+import { TYPE_MESSAGEBOX, TYPE_PANEL } from "./utilities";
+
 export type PanelProps = {
 	open: boolean;
 	onOpenChange: (open: boolean) => void;
 	title: string;
 	children: React.ReactNode;
+	footer?: React.ReactNode;
 	borderKind?: "dark" | "light";
+	kind?: typeof TYPE_PANEL | typeof TYPE_MESSAGEBOX;
 };

--- a/packages/ui-components/src/components/Panel/__tests__/Panel.test.tsx
+++ b/packages/ui-components/src/components/Panel/__tests__/Panel.test.tsx
@@ -1,6 +1,10 @@
 import { render, screen } from "@testing-library/react";
 
 import { expectToHaveClasses } from "../../../common/__tests__/helpers";
+import {
+	MESSSAGEBOX_CLASSNAME,
+	PANEL_CLASSNAME,
+} from "../../../common/constants";
 import { Panel } from "../..";
 
 const PANEL_CONTENT = "Panel Content Lorem";
@@ -23,6 +27,7 @@ describe("Panel modifiers", () => {
 		const panel = screen.getByRole("dialog");
 
 		expectToHaveClasses(panel, [
+			PANEL_CLASSNAME,
 			"flex",
 			"h-full",
 			"min-h-[95%]",
@@ -36,6 +41,56 @@ describe("Panel modifiers", () => {
 			"sm:border-2",
 			"sm:border-border-light",
 			"md:max-w-2xl",
+		]);
+	});
+
+	it("should render a responsive panel with dark borders", async () => {
+		render(<SimplePanel borderKind="dark" />);
+		const panel = screen.getByRole("dialog");
+
+		expectToHaveClasses(panel, [
+			PANEL_CLASSNAME,
+			"flex",
+			"h-full",
+			"min-h-[95%]",
+			"w-full",
+			"flex-col",
+			"bg-surface-medium",
+			"sm:h-auto",
+			"sm:min-h-[10rem]",
+			"sm:w-[95%]",
+			"sm:rounded-lg",
+			"sm:border-2",
+			"sm:border-border-dark",
+			"md:max-w-2xl",
+		]);
+	});
+
+	it("should render a responsive messagebox", async () => {
+		render(<SimplePanel kind="messagebox" />);
+		const panel = screen.getByRole("dialog");
+
+		expectToHaveClasses(panel, [
+			MESSSAGEBOX_CLASSNAME,
+			"w-[95%]",
+			"rounded-lg",
+			"sm:w-[50%]",
+			"border-2",
+			"border-border-light",
+		]);
+	});
+
+	it("should render a responsive messagebox wit dark borders", async () => {
+		render(<SimplePanel kind="messagebox" borderKind="dark" />);
+		const panel = screen.getByRole("dialog");
+
+		expectToHaveClasses(panel, [
+			MESSSAGEBOX_CLASSNAME,
+			"w-[95%]",
+			"rounded-lg",
+			"sm:w-[50%]",
+			"border-2",
+			"border-border-dark",
 		]);
 	});
 
@@ -56,5 +111,15 @@ describe("Panel modifiers", () => {
 		expect(document.title).toBe("Panel Header 2");
 		rerender(<SimplePanel title="Panel Header 1" open />);
 		expect(document.title).toBe("Panel Header 1");
+	});
+
+	it("should render the panel content", () => {
+		render(<SimplePanel />);
+		expect(screen.getByText(PANEL_CONTENT)).toBeInTheDocument();
+	});
+
+	it("should render the panel footer", () => {
+		render(<SimplePanel footer={<span>Footer</span>} />);
+		expect(screen.getByText("Footer")).toBeInTheDocument();
 	});
 });

--- a/packages/ui-components/src/components/Panel/__tests__/Panel.test.tsx
+++ b/packages/ui-components/src/components/Panel/__tests__/Panel.test.tsx
@@ -2,7 +2,7 @@ import { render, screen } from "@testing-library/react";
 
 import { expectToHaveClasses } from "../../../common/__tests__/helpers";
 import {
-	MESSSAGEBOX_CLASSNAME,
+	MESSAGEBOX_CLASSNAME,
 	PANEL_CLASSNAME,
 } from "../../../common/constants";
 import { Panel } from "../..";
@@ -71,7 +71,7 @@ describe("Panel modifiers", () => {
 		const panel = screen.getByRole("dialog");
 
 		expectToHaveClasses(panel, [
-			MESSSAGEBOX_CLASSNAME,
+			MESSAGEBOX_CLASSNAME,
 			"w-[95%]",
 			"rounded-lg",
 			"sm:w-[50%]",
@@ -85,7 +85,7 @@ describe("Panel modifiers", () => {
 		const panel = screen.getByRole("dialog");
 
 		expectToHaveClasses(panel, [
-			MESSSAGEBOX_CLASSNAME,
+			MESSAGEBOX_CLASSNAME,
 			"w-[95%]",
 			"rounded-lg",
 			"sm:w-[50%]",

--- a/packages/ui-components/src/components/Panel/utilities.ts
+++ b/packages/ui-components/src/components/Panel/utilities.ts
@@ -14,18 +14,14 @@ export const getPanelClassName = ({
 }) => {
 	return {
 		main: clsx("flex flex-col bg-surface-medium md:max-w-2xl", {
-			[`${PANEL_CLASSNAME} h-full min-h-[95%] w-full sm:h-auto sm:min-h-[10rem] sm:w-[95%] sm:rounded-lg`]:
+			[`${PANEL_CLASSNAME} h-full min-h-[95%] w-full sm:h-auto sm:min-h-[10rem] sm:w-[95%] sm:rounded-lg sm:border-2`]:
 				kind === TYPE_PANEL,
-			[`${MESSSAGEBOX_CLASSNAME} w-[95%] rounded-lg sm:w-[50%]`]:
+			[`${MESSSAGEBOX_CLASSNAME} w-[95%] rounded-lg border-2 sm:w-[50%] `]:
 				kind === TYPE_MESSAGEBOX,
-			"sm:border-2 sm:border-border-dark":
-				borderKind === "dark" && kind === TYPE_PANEL,
-			"sm:border-2 sm:border-border-light":
-				borderKind === "light" && kind === TYPE_PANEL,
-			"border-2 border-border-dark":
-				borderKind === "dark" && kind === TYPE_MESSAGEBOX,
-			"border-2 border-border-light":
-				borderKind === "light" && kind === TYPE_MESSAGEBOX,
+			"sm:border-border-dark": borderKind === "dark" && kind === TYPE_PANEL,
+			"sm:border-border-light": borderKind === "light" && kind === TYPE_PANEL,
+			"border-border-dark": borderKind === "dark" && kind === TYPE_MESSAGEBOX,
+			"border-border-light": borderKind === "light" && kind === TYPE_MESSAGEBOX,
 		}),
 		content: "flex flex-grow flex-col p-2 sm:p-4",
 	};

--- a/packages/ui-components/src/components/Panel/utilities.ts
+++ b/packages/ui-components/src/components/Panel/utilities.ts
@@ -1,6 +1,6 @@
 import clsx from "clsx";
 
-import { MESSSAGEBOX_CLASSNAME, PANEL_CLASSNAME } from "../../common/constants";
+import { MESSAGEBOX_CLASSNAME, PANEL_CLASSNAME } from "../../common/constants";
 
 export const TYPE_PANEL = "panel";
 export const TYPE_MESSAGEBOX = "messagebox";
@@ -16,7 +16,7 @@ export const getPanelClassName = ({
 		main: clsx("flex flex-col bg-surface-medium md:max-w-2xl", {
 			[`${PANEL_CLASSNAME} h-full min-h-[95%] w-full sm:h-auto sm:min-h-[10rem] sm:w-[95%] sm:rounded-lg sm:border-2`]:
 				kind === TYPE_PANEL,
-			[`${MESSSAGEBOX_CLASSNAME} w-[95%] rounded-lg border-2 sm:w-[50%]`]:
+			[`${MESSAGEBOX_CLASSNAME} w-[95%] rounded-lg border-2 sm:w-[50%]`]:
 				kind === TYPE_MESSAGEBOX,
 			"sm:border-border-dark": borderKind === "dark" && kind === TYPE_PANEL,
 			"sm:border-border-light": borderKind === "light" && kind === TYPE_PANEL,

--- a/packages/ui-components/src/components/Panel/utilities.ts
+++ b/packages/ui-components/src/components/Panel/utilities.ts
@@ -16,7 +16,7 @@ export const getPanelClassName = ({
 		main: clsx("flex flex-col bg-surface-medium md:max-w-2xl", {
 			[`${PANEL_CLASSNAME} h-full min-h-[95%] w-full sm:h-auto sm:min-h-[10rem] sm:w-[95%] sm:rounded-lg sm:border-2`]:
 				kind === TYPE_PANEL,
-			[`${MESSSAGEBOX_CLASSNAME} w-[95%] rounded-lg border-2 sm:w-[50%] `]:
+			[`${MESSSAGEBOX_CLASSNAME} w-[95%] rounded-lg border-2 sm:w-[50%]`]:
 				kind === TYPE_MESSAGEBOX,
 			"sm:border-border-dark": borderKind === "dark" && kind === TYPE_PANEL,
 			"sm:border-border-light": borderKind === "light" && kind === TYPE_PANEL,

--- a/packages/ui-components/src/components/Panel/utilities.ts
+++ b/packages/ui-components/src/components/Panel/utilities.ts
@@ -1,0 +1,32 @@
+import clsx from "clsx";
+
+import { MESSSAGEBOX_CLASSNAME, PANEL_CLASSNAME } from "../../common/constants";
+
+export const TYPE_PANEL = "panel";
+export const TYPE_MESSAGEBOX = "messagebox";
+
+export const getPanelClassName = ({
+	kind,
+	borderKind,
+}: {
+	kind: string;
+	borderKind: string;
+}) => {
+	return {
+		main: clsx("flex flex-col bg-surface-medium md:max-w-2xl", {
+			[`${PANEL_CLASSNAME} h-full min-h-[95%] w-full sm:h-auto sm:min-h-[10rem] sm:w-[95%] sm:rounded-lg`]:
+				kind === TYPE_PANEL,
+			[`${MESSSAGEBOX_CLASSNAME} w-[95%] rounded-lg sm:w-[50%]`]:
+				kind === TYPE_MESSAGEBOX,
+			"sm:border-2 sm:border-border-dark":
+				borderKind === "dark" && kind === TYPE_PANEL,
+			"sm:border-2 sm:border-border-light":
+				borderKind === "light" && kind === TYPE_PANEL,
+			"border-2 border-border-dark":
+				borderKind === "dark" && kind === TYPE_MESSAGEBOX,
+			"border-2 border-border-light":
+				borderKind === "light" && kind === TYPE_MESSAGEBOX,
+		}),
+		content: "flex flex-grow flex-col p-2 sm:p-4",
+	};
+};


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a `WithMessageBox` story in the documentation, showcasing a new message box feature with logout functionality.
  - Added a `footer` property to the `Panel` component, allowing for custom footers with buttons.

- **Documentation**
  - Updated `Menu` and `Panel` stories to reflect new features and usage of the `Panel` component.

- **Style**
  - Implemented new class names for styling `Panel` and `MessageBox` components.

- **Tests**
  - Added tests for the new `Panel` content and footer rendering.

- **Refactor**
  - Removed unused imports and updated variable names for clarity in the `Panel` component.
  - Enhanced CSS class generation logic for `Panel` and `MessageBox` components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->