### PR TITLE
fix(Panel): original page title is unknown when opened

### DIFF
--- a/packages/ui-components/src/components/Panel/Panel.tsx
+++ b/packages/ui-components/src/components/Panel/Panel.tsx
@@ -31,7 +31,7 @@ export const Panel = ({
 	useEffect(() => {
 		if (open) {
 			originalTitleRef.current = document.title;
-			document.title = title;
+			document.title = `${title} | ${originalTitleRef.current}`;
 		}
 		return () => {
 			if (open) {

--- a/packages/ui-components/src/components/Panel/__tests__/Panel.test.tsx
+++ b/packages/ui-components/src/components/Panel/__tests__/Panel.test.tsx
@@ -94,25 +94,6 @@ describe("Panel modifiers", () => {
 		]);
 	});
 
-	it("should reflect the panel title props in the browser title", () => {
-		render(<SimplePanel title="Panel Header" open />);
-		expect(document.title).toBe("Panel Header");
-	});
-
-	it("should return the document title to what it was before the panel opened", () => {
-		const docTitle = document.title;
-		const { unmount } = render(<SimplePanel title="Panel Header" open />);
-		unmount();
-		expect(document.title).toBe(docTitle);
-	});
-
-	it('Should set the document title to the Panel title after the "title" prop change', () => {
-		const { rerender } = render(<SimplePanel title="Panel Header 2" open />);
-		expect(document.title).toBe("Panel Header 2");
-		rerender(<SimplePanel title="Panel Header 1" open />);
-		expect(document.title).toBe("Panel Header 1");
-	});
-
 	it("should render the panel content", () => {
 		render(<SimplePanel />);
 		expect(screen.getByText(PANEL_CONTENT)).toBeInTheDocument();
@@ -121,5 +102,29 @@ describe("Panel modifiers", () => {
 	it("should render the panel footer", () => {
 		render(<SimplePanel footer={<span>Footer</span>} />);
 		expect(screen.getByText("Footer")).toBeInTheDocument();
+	});
+});
+
+describe("Page and Panel titles", () => {
+	it("should reflect the panel title props in the browser title", () => {
+		document.title = "My page";
+		render(<SimplePanel title="Panel Header" open />);
+		expect(document.title).toBe("Panel Header | My page");
+	});
+
+	it("should return the document title to what it was before the panel opened", () => {
+		document.title = "My page";
+		const docTitle = document.title;
+		const { unmount } = render(<SimplePanel title="Panel Header" open />);
+		unmount();
+		expect(document.title).toBe(docTitle);
+	});
+
+	it('Should set the document title to the Panel title after the "title" prop change', () => {
+		document.title = "My page";
+		const { rerender } = render(<SimplePanel title="Panel Header 2" open />);
+		expect(document.title).toBe("Panel Header 2 | My page");
+		rerender(<SimplePanel title="Panel Header 1" open />);
+		expect(document.title).toBe("Panel Header 1 | My page");
 	});
 });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced the panel component to dynamically update the document title when the panel is open.

- **Tests**
  - Improved tests for panel content and footer rendering.
  - Added tests to ensure correct document title manipulation based on panel states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->