### PR TITLE
feat(Menu): adding onOpenChange callback

### DIFF
--- a/packages/ui-components/src/components/Menu/Menu.tsx
+++ b/packages/ui-components/src/components/Menu/Menu.tsx
@@ -31,7 +31,14 @@ export const MenuComponent = forwardRef<
 	MenuProps & React.HTMLProps<HTMLButtonElement>
 >(
 	(
-		{ children, label, icon, defaultPlacement = "bottom-start", ...props },
+		{
+			children,
+			label,
+			icon,
+			defaultPlacement = "bottom-start",
+			onOpenChange,
+			...props
+		},
 		userRef,
 	) => {
 		const [isOpen, setIsOpen] = useState(false);
@@ -49,7 +56,10 @@ export const MenuComponent = forwardRef<
 		const { floatingStyles, refs, context } = useFloating<HTMLButtonElement>({
 			nodeId,
 			open: isOpen,
-			onOpenChange: setIsOpen,
+			onOpenChange: (args) => {
+				setIsOpen(args);
+				onOpenChange?.(args);
+			},
 			placement: defaultPlacement,
 			strategy: "fixed",
 			middleware: [offset({ mainAxis: 10 }), flip(), shift()],
@@ -90,6 +100,7 @@ export const MenuComponent = forwardRef<
 
 			function handleTreeClick() {
 				setIsOpen(false);
+				onOpenChange?.(false);
 			}
 
 			tree.events.on("click", handleTreeClick);
@@ -97,7 +108,7 @@ export const MenuComponent = forwardRef<
 			return () => {
 				tree.events.off("click", handleTreeClick);
 			};
-		}, [tree, nodeId]);
+		}, [tree, nodeId, onOpenChange]);
 
 		useEffect(() => {
 			if (isOpen && tree) {

--- a/packages/ui-components/src/components/Menu/MenuTypes.d.ts
+++ b/packages/ui-components/src/components/Menu/MenuTypes.d.ts
@@ -5,6 +5,7 @@ export interface MenuProps {
 	label?: string;
 	children?: React.ReactNode;
 	defaultPlacement?: Placement;
+	onOpenChange?: (open: boolean) => void;
 }
 
 export interface MenuItemProps {

--- a/packages/ui-components/src/components/Menu/__tests__/Menu.test.tsx
+++ b/packages/ui-components/src/components/Menu/__tests__/Menu.test.tsx
@@ -128,6 +128,31 @@ describe("Menu behaviors", () => {
 		expect(trigger).toHaveFocus();
 	});
 
+	it("should trigger the Menu onOpenChange callback when opened and closed", async () => {
+		const onOpenChange = vi.fn();
+		const { user } = renderWithUserEvent(
+			<Menu label={MENU_TRIGGER_LABEL} onOpenChange={onOpenChange}>
+				<MenuItem label={FIRST_MENU_ITEM} />
+				<MenuItem label={SECOND_MENU_ITEM} />
+				<MenuItem label={THIRD_MENU_ITEM} disabled />
+				<MenuItem label={FOURTH_MENU_ITEM} />
+			</Menu>,
+		);
+		const trigger = screen.getByLabelText(MENU_TRIGGER_LABEL);
+		await user.click(trigger);
+		expect(onOpenChange).toHaveBeenCalledWith(true);
+
+		const firstMenuItem = screen.getByRole("menuitem", {
+			name: FIRST_MENU_ITEM,
+		});
+
+		expect(firstMenuItem).toHaveFocus();
+		expect(document.activeElement).toBe(firstMenuItem);
+		await user.click(firstMenuItem);
+
+		expect(onOpenChange).toHaveBeenCalledWith(false);
+	});
+
 	it("should trigger the MenuItem onClick callback when a menuitem is selected", async () => {
 		const onClick = vi.fn();
 		const { user } = renderWithUserEvent(
@@ -172,7 +197,7 @@ describe("Menu behaviors", () => {
 		expect(onFocus).toHaveBeenCalled();
 	});
 
-	it("should a menu separator when menu is opened", async () => {
+	it("should have a menu separator when menu is opened", async () => {
 		const { user } = renderWithUserEvent(
 			<SimpleMenu label={MENU_TRIGGER_LABEL} />,
 		);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Menu component now supports an `onOpenChange` callback for better handling of its open state.

- **Documentation**
  - Updated the `MenuProps` interface documentation to reflect the new `onOpenChange` property.

- **Tests**
  - Added tests to verify the `onOpenChange` callback is triggered when the menu is opened and closed.
  - Corrected the test description for the menu separator presence check.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->