### PR TITLE
feat: adding useLocalStorage hook

### DIFF
--- a/packages/ui-hooks/src/hooks/__tests__/useEventListener.test.ts
+++ b/packages/ui-hooks/src/hooks/__tests__/useEventListener.test.ts
@@ -1,0 +1,152 @@
+import { fireEvent, renderHook } from "@testing-library/react";
+
+import { useEventListener } from "../useEventListener";
+
+declare global {
+	interface WindowEventMap {
+		"test-event": CustomEvent;
+	}
+
+	interface HTMLElementEventMap {
+		"test-event": CustomEvent;
+	}
+
+	interface DocumentEventMap {
+		"test-event": CustomEvent;
+	}
+}
+
+const windowAddEventListenerSpy = vi.spyOn(window, "addEventListener");
+const windowRemoveEventListenerSpy = vi.spyOn(window, "removeEventListener");
+
+const ref = { current: document.createElement("div") };
+const refAddEventListenerSpy = vi.spyOn(ref.current, "addEventListener");
+const refRemoveEventListenerSpy = vi.spyOn(ref.current, "removeEventListener");
+
+const docRef = { current: window.document };
+const docAddEventListenerSpy = vi.spyOn(docRef.current, "addEventListener");
+const docRemoveEventListenerSpy = vi.spyOn(
+	docRef.current,
+	"removeEventListener",
+);
+
+describe("useEventListener()", () => {
+	afterEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("should bind/unbind the event listener to the window when element is not provided", () => {
+		const eventName = "test-event";
+		const handler = vi.fn();
+		const options = undefined;
+
+		const { unmount } = renderHook(() => useEventListener(eventName, handler));
+
+		expect(windowAddEventListenerSpy).toHaveBeenCalledWith(
+			eventName,
+			expect.any(Function),
+			options,
+		);
+
+		unmount();
+
+		expect(windowRemoveEventListenerSpy).toHaveBeenCalledWith(
+			eventName,
+			expect.any(Function),
+			options,
+		);
+	});
+
+	it("should bind/unbind the event listener to the element when element is provided", () => {
+		const eventName = "test-event";
+		const handler = vi.fn();
+		const options = undefined;
+
+		const { unmount } = renderHook(() =>
+			useEventListener(eventName, handler, ref, options),
+		);
+
+		expect(refAddEventListenerSpy).toHaveBeenCalledTimes(1);
+		expect(refAddEventListenerSpy).toHaveBeenCalledWith(
+			eventName,
+			expect.any(Function),
+			options,
+		);
+
+		unmount();
+
+		expect(refRemoveEventListenerSpy).toHaveBeenCalledWith(
+			eventName,
+			expect.any(Function),
+			options,
+		);
+	});
+
+	it("should bind/unbind the event listener to the document when document is provided", () => {
+		const eventName = "test-event";
+		const handler = vi.fn();
+		const options = undefined;
+
+		const { unmount } = renderHook(() =>
+			useEventListener(eventName, handler, docRef, options),
+		);
+
+		expect(docAddEventListenerSpy).toHaveBeenCalledTimes(1);
+		expect(docAddEventListenerSpy).toHaveBeenCalledWith(
+			eventName,
+			expect.any(Function),
+			options,
+		);
+
+		unmount();
+
+		expect(docRemoveEventListenerSpy).toHaveBeenCalledWith(
+			eventName,
+			expect.any(Function),
+			options,
+		);
+	});
+
+	it("should pass the options to the event listener", () => {
+		const eventName = "test-event";
+		const handler = vi.fn();
+		const options = {
+			passive: true,
+			once: true,
+			capture: true,
+		};
+
+		renderHook(() => useEventListener(eventName, handler, undefined, options));
+
+		expect(windowAddEventListenerSpy).toHaveBeenCalledWith(
+			eventName,
+			expect.any(Function),
+			options,
+		);
+	});
+
+	it("should call the event listener handler when the event is triggered", () => {
+		const eventName = "click";
+		const handler = vi.fn();
+
+		renderHook(() => useEventListener(eventName, handler, ref));
+
+		fireEvent.click(ref.current);
+
+		expect(handler).toHaveBeenCalledTimes(1);
+	});
+
+	it("should have the correct event type", () => {
+		const clickHandler = vi.fn();
+		const keydownHandler = vi.fn();
+
+		renderHook(() => useEventListener("click", clickHandler, ref));
+		renderHook(() => useEventListener("keydown", keydownHandler, ref));
+
+		fireEvent.click(ref.current);
+		fireEvent.keyDown(ref.current);
+
+		expect(clickHandler).toHaveBeenCalledWith(expect.any(MouseEvent));
+		expect(keydownHandler).toHaveBeenCalledWith(expect.any(KeyboardEvent));
+	});
+});

--- a/packages/ui-hooks/src/hooks/__tests__/useLocalStorage.test.tsx
+++ b/packages/ui-hooks/src/hooks/__tests__/useLocalStorage.test.tsx
@@ -1,0 +1,397 @@
+import { act, renderHook } from "@testing-library/react";
+
+import { useLocalStorage } from "../useLocalStorage";
+
+class LocalStorageMock {
+	store: Record<string, unknown> = {};
+
+	clear() {
+		this.store = {};
+	}
+
+	getItem(key: string) {
+		return this.store[key] || null;
+	}
+
+	setItem(key: string, value: unknown) {
+		this.store[key] = value + "";
+		window.dispatchEvent(
+			new CustomEvent("storage", {
+				detail: { key, value },
+			}),
+		);
+	}
+
+	removeItem(key: string) {
+		delete this.store[key];
+	}
+}
+
+describe("useLocalStorage()", () => {
+	beforeEach(() => {
+		Object.defineProperty(window, "localStorage", {
+			value: new LocalStorageMock(),
+		});
+		window.localStorage.clear();
+	});
+	afterEach(() => {
+		vi.clearAllMocks();
+		Object.defineProperty(window, "localStorage", {
+			value: null,
+		});
+	});
+
+	it("should return undefined when there is no defaultValue", () => {
+		const { result } = renderHook(() => useLocalStorage({ key: "key" }));
+		expect(result.current[0]).toBeUndefined();
+		expect(window.localStorage.getItem("key")).toBe("undefined");
+	});
+
+	it("should return the initial state when defaultValue is a string", () => {
+		const { result } = renderHook(() =>
+			useLocalStorage({ key: "key", defaultValue: "value" }),
+		);
+		expect(result.current[0]).toBe("value");
+	});
+
+	it("should initialize localStorage when defaultValue is a string", () => {
+		renderHook(() => useLocalStorage({ key: "key", defaultValue: "value" }));
+		expect(window.localStorage.getItem("key")).toBe(JSON.stringify("value"));
+	});
+
+	it("should return the initial state when defaultValue is a function", () => {
+		const { result } = renderHook(() =>
+			useLocalStorage({ key: "key", defaultValue: () => "value" }),
+		);
+		expect(result.current[0]).toBe("value");
+	});
+
+	it("should initialize localStorage when defaultValue is a function", () => {
+		renderHook(() =>
+			useLocalStorage({ key: "key", defaultValue: () => "value" }),
+		);
+		expect(window.localStorage.getItem("key")).toBe(JSON.stringify("value"));
+	});
+
+	it("should return the initial state when defaultValue is an array", () => {
+		const { result } = renderHook(() =>
+			useLocalStorage({ key: "key", defaultValue: [1, 2] }),
+		);
+		expect(result.current[0]).toEqual([1, 2]);
+	});
+
+	it("should initialize localStorage when defaultValue is a array", () => {
+		renderHook(() => useLocalStorage({ key: "key", defaultValue: [1, 2] }));
+		expect(window.localStorage.getItem("key")).toBe(JSON.stringify([1, 2]));
+	});
+
+	it("should update the state when setState is called", () => {
+		const { result } = renderHook(() =>
+			useLocalStorage({ key: "key", defaultValue: "value" }),
+		);
+		act(() => {
+			const setState = result.current[1];
+			setState("edited");
+		});
+		expect(result.current[0]).toBe("edited");
+	});
+
+	it("should update localStorage when setState is called", () => {
+		const { result } = renderHook(() =>
+			useLocalStorage({ key: "key", defaultValue: "value" }),
+		);
+		act(() => {
+			const setState = result.current[1];
+			setState("edited");
+		});
+		expect(window.localStorage.getItem("key")).toBe(JSON.stringify("edited"));
+	});
+
+	it("should revert state and localStorage to defaultValue when reset callback is called", () => {
+		const { result } = renderHook(() =>
+			useLocalStorage({ key: "key", defaultValue: "value" }),
+		);
+		expect(window.localStorage.getItem("key")).toBe(JSON.stringify("value"));
+		act(() => {
+			const setState = result.current[1];
+			setState("edited");
+		});
+		expect(window.localStorage.getItem("key")).toBe(JSON.stringify("edited"));
+		expect(result.current[0]).toBe("edited");
+		act(() => {
+			const resetValue = result.current[2];
+			resetValue();
+		});
+		expect(window.localStorage.getItem("key")).toBe(JSON.stringify("value"));
+		expect(result.current[0]).toBe("value");
+	});
+
+	it("should retain the state when new value is undefined", () => {
+		const { result } = renderHook(() =>
+			useLocalStorage<string | undefined>({
+				key: "key",
+				defaultValue: "value",
+			}),
+		);
+		act(() => {
+			const setState = result.current[1];
+			setState(undefined);
+		});
+		expect(result.current[0]).toBe("value");
+	});
+
+	it("should retain the localStorage when new value is undefined", () => {
+		const { result } = renderHook(() =>
+			useLocalStorage<string | undefined>({
+				key: "key",
+				defaultValue: "value",
+			}),
+		);
+		expect(window.localStorage.getItem("key")).toBe(JSON.stringify("value"));
+		act(() => {
+			const setState = result.current[1];
+			setState(undefined);
+		});
+		expect(window.localStorage.getItem("key")).toBe(JSON.stringify("value"));
+	});
+
+	it("should update the state when new value is null", () => {
+		const { result } = renderHook(() =>
+			useLocalStorage<string | null>({ key: "key", defaultValue: "value" }),
+		);
+		expect(result.current[0]).toBe("value");
+		act(() => {
+			const setState = result.current[1];
+			setState(null);
+		});
+		expect(result.current[0]).toBeNull();
+	});
+
+	it("should update the localStorage when new value is null", () => {
+		const { result } = renderHook(() =>
+			useLocalStorage<string | null>({ key: "key", defaultValue: "value" }),
+		);
+		expect(window.localStorage.getItem("key")).toBe(JSON.stringify("value"));
+		act(() => {
+			const setState = result.current[1];
+			setState(null);
+		});
+		expect(window.localStorage.getItem("key")).toBe("null");
+	});
+
+	it("should update the state with a callback function", () => {
+		const { result } = renderHook(() =>
+			useLocalStorage({
+				key: "count",
+				defaultValue: 2,
+			}),
+		);
+		act(() => {
+			const setState = result.current[1];
+			setState((prev) => prev + 1);
+		});
+		expect(result.current[0]).toBe(3);
+	});
+
+	it("should update the localStorage with a callback function", () => {
+		const { result } = renderHook(() =>
+			useLocalStorage({
+				key: "count",
+				defaultValue: 2,
+			}),
+		);
+		expect(window.localStorage.getItem("count")).toEqual("2");
+		act(() => {
+			const setState = result.current[1];
+			setState((prev) => prev + 1);
+		});
+		expect(window.localStorage.getItem("count")).toEqual("3");
+	});
+});
+
+describe("useLocalStorage() event based updates", () => {
+	beforeEach(() => {
+		Object.defineProperty(window, "localStorage", {
+			value: new LocalStorageMock(),
+		});
+		window.localStorage.clear();
+	});
+	afterEach(() => {
+		vi.clearAllMocks();
+		Object.defineProperty(window, "localStorage", {
+			value: null,
+		});
+	});
+
+	it("should update the state of all hooks when one is updated", () => {
+		const { result: A } = renderHook(() =>
+			useLocalStorage({
+				key: "key",
+				defaultValue: "value",
+			}),
+		);
+		expect(window.localStorage.getItem("key")).toBe(JSON.stringify("value"));
+		const { result: B } = renderHook(() =>
+			useLocalStorage({
+				key: "key",
+				defaultValue: "value",
+			}),
+		);
+
+		act(() => {
+			const setState = A.current[1];
+			setState("edited");
+		});
+		expect(A.current[0]).toBe("edited");
+		expect(B.current[0]).toBe("edited");
+		expect(window.localStorage.getItem("key")).toBe(JSON.stringify("edited"));
+	});
+
+	it("should update the state of all hooks when one is reset", () => {
+		const { result: A } = renderHook(() =>
+			useLocalStorage({
+				key: "key",
+				defaultValue: "value",
+			}),
+		);
+		expect(window.localStorage.getItem("key")).toBe(JSON.stringify("value"));
+		const { result: B } = renderHook(() =>
+			useLocalStorage({
+				key: "key",
+				defaultValue: "value",
+			}),
+		);
+
+		act(() => {
+			const resetState = A.current[2];
+			resetState();
+		});
+		expect(A.current[0]).toBe("value");
+		expect(B.current[0]).toBe("value");
+		expect(window.localStorage.getItem("key")).toBe(JSON.stringify("value"));
+	});
+
+	it("should NOT update the state of all hooks when one is updated", () => {
+		const { result: A } = renderHook(() =>
+			useLocalStorage({
+				key: "key1",
+				defaultValue: "value",
+			}),
+		);
+		expect(window.localStorage.getItem("key1")).toBe(JSON.stringify("value"));
+		const { result: B } = renderHook(() =>
+			useLocalStorage({
+				key: "key2",
+				defaultValue: "value",
+			}),
+		);
+		expect(window.localStorage.getItem("key2")).toBe(JSON.stringify("value"));
+		act(() => {
+			const setState = A.current[1];
+			setState("edited");
+		});
+		expect(A.current[0]).toBe("edited");
+		expect(B.current[0]).toBe("value");
+		expect(window.localStorage.getItem("key1")).toBe(JSON.stringify("edited"));
+		expect(window.localStorage.getItem("key2")).toBe(JSON.stringify("value"));
+	});
+
+	it("should NOT update the state of all hooks when one is reset", () => {
+		const { result: A } = renderHook(() =>
+			useLocalStorage({
+				key: "key1",
+				defaultValue: "value",
+			}),
+		);
+		expect(window.localStorage.getItem("key1")).toBe(JSON.stringify("value"));
+		const { result: B } = renderHook(() =>
+			useLocalStorage({
+				key: "key2",
+				defaultValue: "value",
+			}),
+		);
+		expect(window.localStorage.getItem("key2")).toBe(JSON.stringify("value"));
+		act(() => {
+			const setStateA = A.current[1];
+			const setStateB = B.current[1];
+			const resetStateB = B.current[2];
+			setStateA("edited");
+			setStateB("edited");
+			resetStateB();
+		});
+		expect(A.current[0]).toBe("edited");
+		expect(B.current[0]).toBe("value");
+		expect(window.localStorage.getItem("key1")).toBe(JSON.stringify("edited"));
+		expect(window.localStorage.getItem("key2")).toBe(JSON.stringify("value"));
+	});
+});
+
+describe("useLocalStorage() custom serialize / deserialize ", () => {
+	beforeEach(() => {
+		Object.defineProperty(window, "localStorage", {
+			value: new LocalStorageMock(),
+		});
+		window.localStorage.clear();
+	});
+	afterEach(() => {
+		vi.clearAllMocks();
+		Object.defineProperty(window, "localStorage", {
+			value: null,
+		});
+	});
+
+	it("should return a stored value with the custom serialize function", () => {
+		const { result } = renderHook(() =>
+			useLocalStorage({
+				key: "key",
+				defaultValue: "value",
+				serialize: (val) => `serialized ${val}`,
+			}),
+		);
+		expect(result.current[0]).toBe("value");
+		act(() => {
+			const setState = result.current[1];
+			setState("edited");
+		});
+
+		expect(result.current[0]).toBe("serialized edited");
+		expect(window.localStorage.getItem("key")).toBe("serialized edited");
+	});
+
+	it("should return a stored value with the custom deserialize function", () => {
+		const { result } = renderHook(() =>
+			useLocalStorage({
+				key: "key",
+				defaultValue: "value",
+				deserialize: (val) => `deserialized ${val}`,
+			}),
+		);
+		expect(result.current[0]).toBe("value");
+		act(() => {
+			const setState = result.current[1];
+			setState("edited");
+		});
+
+		expect(result.current[0]).toBe('deserialized "edited"');
+		expect(window.localStorage.getItem("key")).toBe(JSON.stringify("edited"));
+	});
+
+	it("should return a stored value with custom de/serialize functions", () => {
+		const { result } = renderHook(() =>
+			useLocalStorage({
+				key: "key",
+				defaultValue: "value",
+				serialize: (val) => `serialized ${val}`,
+				deserialize: (val) => `deserialized ${val}`,
+			}),
+		);
+		expect(result.current[0]).toBe("value");
+		act(() => {
+			const setState = result.current[1];
+			setState("edited");
+		});
+
+		expect(result.current[0]).toBe("deserialized serialized edited");
+		expect(window.localStorage.getItem("key")).toBe("serialized edited");
+	});
+});

--- a/packages/ui-hooks/src/hooks/index.ts
+++ b/packages/ui-hooks/src/hooks/index.ts
@@ -1,5 +1,6 @@
+import { useLocalStorage } from "./useLocalStorage";
 import { useMergeRefs } from "./useMergeRefs";
 import { useUncontrolled } from "./useUncontrolled";
 import { useUniqueId } from "./useUniqueId";
 
-export { useMergeRefs, useUncontrolled, useUniqueId };
+export { useLocalStorage, useMergeRefs, useUncontrolled, useUniqueId };

--- a/packages/ui-hooks/src/hooks/useEventListener.ts
+++ b/packages/ui-hooks/src/hooks/useEventListener.ts
@@ -1,0 +1,77 @@
+import { RefObject, useEffect, useRef } from "react";
+
+function useEventListener<K extends keyof MediaQueryListEventMap>(
+	eventName: K,
+	handler: (event: MediaQueryListEventMap[K]) => void,
+	element: RefObject<MediaQueryList>,
+	options?: boolean | AddEventListenerOptions,
+): void;
+
+function useEventListener<K extends keyof WindowEventMap>(
+	eventName: K,
+	handler: (event: WindowEventMap[K]) => void,
+	element?: undefined,
+	options?: boolean | AddEventListenerOptions,
+): void;
+
+function useEventListener<
+	K extends keyof HTMLElementEventMap,
+	T extends HTMLElement = HTMLDivElement,
+>(
+	eventName: K,
+	handler: (event: HTMLElementEventMap[K]) => void,
+	element: RefObject<T>,
+	options?: boolean | AddEventListenerOptions,
+): void;
+
+function useEventListener<K extends keyof DocumentEventMap>(
+	eventName: K,
+	handler: (event: DocumentEventMap[K]) => void,
+	element: RefObject<Document>,
+	options?: boolean | AddEventListenerOptions,
+): void;
+
+function useEventListener<
+	KW extends keyof WindowEventMap,
+	KH extends keyof HTMLElementEventMap,
+	KM extends keyof MediaQueryListEventMap,
+	T extends HTMLElement | MediaQueryList | void = void,
+>(
+	eventName: KW | KH | KM,
+	handler: (
+		event:
+			| WindowEventMap[KW]
+			| HTMLElementEventMap[KH]
+			| MediaQueryListEventMap[KM]
+			| Event,
+	) => void,
+	element?: RefObject<T>,
+	options?: boolean | AddEventListenerOptions,
+) {
+	const cachedHandler = useRef(handler);
+
+	useEffect(() => {
+		cachedHandler.current = handler;
+	}, [handler]);
+
+	useEffect(() => {
+		const targetElement: T | Window = element?.current ?? window;
+
+		/* v8 ignore next 3 */
+		if (!(targetElement && targetElement.addEventListener)) {
+			return;
+		}
+
+		// Create event listener that calls handler function stored in ref
+		const listener: typeof handler = (event) => cachedHandler.current(event);
+
+		targetElement.addEventListener(eventName, listener, options);
+
+		// Remove event listener on cleanup
+		return () => {
+			targetElement.removeEventListener(eventName, listener, options);
+		};
+	}, [eventName, element, options]);
+}
+
+export { useEventListener };

--- a/packages/ui-hooks/src/hooks/useLocalStorage.ts
+++ b/packages/ui-hooks/src/hooks/useLocalStorage.ts
@@ -1,0 +1,173 @@
+/* eslint-disable no-console */
+
+import { useCallback, useState } from "react";
+
+import { useEventListener } from "./useEventListener";
+
+const CUSTOM_EVENT_NAME = "av-local-storage";
+
+declare global {
+	interface WindowEventMap {
+		[CUSTOM_EVENT_NAME]: CustomEvent;
+	}
+}
+
+export interface StorageProperties<T> {
+	/**
+	 * Storage key.
+	 */
+	key: string;
+
+	/**
+	 * Default value that will be set if value is not found in storage.
+	 */
+	defaultValue?: T;
+
+	/**
+	 * Function to serialize value into string to be saved in storage.
+	 */
+	serialize?: (value: T) => string;
+
+	/**
+	 * Function to deserialize string value from storage to value.
+	 */
+	deserialize?: (value: string | undefined) => T;
+}
+
+const serializeJSON = <T>(value: T) => {
+	try {
+		return JSON.stringify(value);
+		/* v8 ignore next 5 */
+	} catch (error) {
+		throw new Error(
+			`@versini/ui-hooks useLocalStorage: Failed to serialize the value`,
+		);
+	}
+};
+
+const deserializeJSON = (value: string | undefined) => {
+	try {
+		return value && JSON.parse(value);
+		/* v8 ignore next 3 */
+	} catch {
+		return value;
+	}
+};
+
+/**
+ *
+ * @example
+ * import { useLocalStorage } from '@versini/ui-hooks';
+ * const [value, setValue] = useLocalStorage({
+ *   key: 'gpt-model',
+ *   defaultValue: 'gpt-3',
+ * });
+ *
+ * setValue('gpt-4');
+ * setValue((current) => (current === 'gpt-3' ? 'gpt-4' : 'gpt-3'));
+ */
+
+export function useLocalStorage<T = string>({
+	key,
+	defaultValue,
+	deserialize = deserializeJSON,
+	serialize = (value: T) => serializeJSON(value),
+}: StorageProperties<T>) {
+	const actualDefaultValue =
+		typeof defaultValue === "function" ? defaultValue() : defaultValue;
+
+	/**
+	 * Read value from localStorage.
+	 * If value is not found, update localStorage with
+	 * actualDefaultValue and return it.
+	 */
+	const readStorageValue = useCallback((): T => {
+		let storageBlockedOrSkipped;
+
+		try {
+			storageBlockedOrSkipped =
+				typeof window === "undefined" ||
+				!("localStorage" in window) ||
+				window.localStorage === null;
+			/* v8 ignore next 3 */
+		} catch (_e) {
+			storageBlockedOrSkipped = true;
+		}
+
+		/* v8 ignore next 4 */
+		if (storageBlockedOrSkipped) {
+			window.localStorage.setItem(key, serialize(actualDefaultValue as T));
+			return actualDefaultValue as T;
+		}
+
+		try {
+			const item = window.localStorage.getItem(key);
+			// return item !== null ? deserialize(item) : (actualDefaultValue as T);
+			if (item !== null) {
+				return deserialize(item);
+			} else {
+				window.localStorage.setItem(key, serialize(actualDefaultValue as T));
+				return actualDefaultValue as T;
+			}
+			/* v8 ignore next 4 */
+		} catch (error) {
+			console.warn(`Error reading localStorage key “${key}”:`, error);
+			return actualDefaultValue as T;
+		}
+	}, [actualDefaultValue, deserialize, key, serialize]);
+
+	const [value, setValue] = useState<T>(readStorageValue());
+
+	/**
+	 * Write value to localStorage and update state.
+	 */
+	const setStorageValue = useCallback(
+		(val: T | ((prevState: T) => T)) => {
+			try {
+				const newValue = val instanceof Function ? val(value) : val;
+				if (newValue === undefined) {
+					return;
+				}
+				window.localStorage.setItem(key, serialize(newValue));
+				setValue(newValue);
+				window.dispatchEvent(new Event(CUSTOM_EVENT_NAME));
+				/* v8 ignore next 3 */
+			} catch (error) {
+				console.warn(`Error setting localStorage key “${key}”:`, error);
+			}
+		},
+		[key, serialize, value],
+	);
+
+	/**
+	 * Remove value from localStorage and reset state.
+	 */
+	const resetStorageValue = useCallback((): T => {
+		window.localStorage.removeItem(key);
+		setValue(readStorageValue());
+		window.dispatchEvent(new Event(CUSTOM_EVENT_NAME));
+		return value;
+	}, [key, readStorageValue, value]);
+
+	/**
+	 * Listen to storage change events and update state.
+	 * This enables usage of `localStorage` hooks in other windows / tabs.
+	 */
+	const handleStorageChangeOnEvent = useCallback(
+		(event: StorageEvent | CustomEvent) => {
+			/* v8 ignore next 3 */
+			if ((event as StorageEvent)?.key && (event as StorageEvent).key !== key) {
+				return;
+			}
+			setValue(readStorageValue());
+		},
+		[key, readStorageValue],
+	);
+	useEventListener(CUSTOM_EVENT_NAME, handleStorageChangeOnEvent);
+
+	return [value, setStorageValue, resetStorageValue] as [
+		T,
+		(val: T | ((prevState: T) => T)) => void,
+		() => void,
+	];
+}


### PR DESCRIPTION
+ useEventListener but it's internal only

fixes #245 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced `useEventListener` hook for managing DOM event listeners.
	- Added `useLocalStorage` hook for handling local storage operations with support for data serialization and synchronization across tabs/windows.

- **Tests**
	- Implemented tests for the `useEventListener` and `useLocalStorage` hooks to ensure reliability and correct functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->