### PR TITLE
fix: removing index from bundle size

### DIFF
--- a/packages/ui-components/bundlesize.config.js
+++ b/packages/ui-components/bundlesize.config.js
@@ -6,10 +6,6 @@ export default {
 	},
 	sizes: [
 		{
-			path: `${bundlePath}/index.html`,
-			limit: "2 KB",
-		},
-		{
 			path: `${bundlePath}/assets/style.css`,
 			limit: "8 KB",
 		},


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Removed the size limit configuration for the web app bundle, enhancing flexibility in content delivery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->