### PR TITLE
fix(Footer): Footer should follow the same rules at the Main component layout

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
 		"lint": "lerna run lint",
 		"lint-staged": "lint-staged --config \"./configuration/lint-staged.config.cjs\"",
 		"prepare": "husky",
-		"test": "lerna run test"
+		"test": "lerna run test",
+		"test:coverage": "lerna run test:coverage"
 	},
 	"devDependencies": {
 		"@node-cli/bundlesize": "4.0.1",

--- a/packages/documentation/src/Components/Footer.stories.tsx
+++ b/packages/documentation/src/Components/Footer.stories.tsx
@@ -4,8 +4,9 @@ import { Footer } from "@versini/ui-components";
 export default {
 	title: "Components/Footer",
 	args: {
-		noPaddings: false,
+		noMargins: false,
 		kind: "dark",
+		raw: false,
 	},
 	argTypes: {
 		kind: {
@@ -16,7 +17,7 @@ export default {
 };
 
 export const Basic: Story<any> = (args) => (
-	<div className="grid">
+	<div className="grid bg-slate-300">
 		<Footer
 			{...args}
 			row1={<div>App Name v1.0.0</div>}

--- a/packages/documentation/src/Components/Main.stories.tsx
+++ b/packages/documentation/src/Components/Main.stories.tsx
@@ -1,5 +1,5 @@
 import type { Story } from "@ladle/react";
-import { Main } from "@versini/ui-components";
+import { Footer, Main } from "@versini/ui-components";
 
 export default {
 	title: "Components/Main",
@@ -9,3 +9,17 @@ export const Basic: Story<any> = (args) => <Main {...args}>hello world </Main>;
 Basic.args = {
 	raw: false,
 };
+
+export const WithFooter: Story<any> = (args) => (
+	<div className="h-full bg-slate-100">
+		<Main {...args} className="bg-slate-300">
+			<div>hello main content</div>
+		</Main>
+
+		<Footer
+			className="bg-slate-300"
+			row1={<div>App Name v1.0.0</div>}
+			row2={<div>something something</div>}
+		/>
+	</div>
+);

--- a/packages/ui-components/src/components/Footer/Footer.tsx
+++ b/packages/ui-components/src/components/Footer/Footer.tsx
@@ -9,18 +9,16 @@ export const Footer = ({
 	kind = "dark",
 	row1,
 	row2,
+	noMargins = false,
 	noPaddings = false,
 	spacing,
+	raw = false,
 }: FooterProps) => {
-	const footerClass = clsx(
-		FOOTER_CLASSNAME,
-		`text-center text-xs text-copy-${kind}`,
-		className,
-		getSpacing(spacing),
-		{
-			"mb-[100px]": !noPaddings,
-		},
-	);
+	const footerClass = clsx(FOOTER_CLASSNAME, className, getSpacing(spacing), {
+		[`text-center text-xs text-copy-${kind}`]: !raw,
+		"mb-[100px]": !noMargins && !noPaddings && !raw,
+		"mt-0 flex w-full flex-col p-2 sm:mt-3 md:mx-auto md:max-w-4xl": !raw,
+	});
 
 	return (
 		<footer className={footerClass}>

--- a/packages/ui-components/src/components/Footer/FooterTypes.d.ts
+++ b/packages/ui-components/src/components/Footer/FooterTypes.d.ts
@@ -10,10 +10,21 @@ export type FooterProps = {
 	 */
 	kind?: "dark" | "light";
 	/**
-	 * Whether or not to render the Footer with paddings.
+	 * Whether or not to render the Footer with margins.
 	 * @default false
 	 */
+	noMargins?: boolean;
+	/**
+	 * Deprecated. Please use `noMargins` instead.
+	 * @default false
+	 * @deprecated
+	 */
 	noPaddings?: boolean;
+	/**
+	 * Whether or not to render the Footer component with no styles.
+	 * @default false
+	 */
+	raw?: boolean;
 	/**
 	 * The content to render in the first row.
 	 */

--- a/packages/ui-components/src/components/Footer/__tests__/Footer.test.tsx
+++ b/packages/ui-components/src/components/Footer/__tests__/Footer.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from "@testing-library/react";
 
+import { expectToHaveClasses } from "../../../common/__tests__/helpers";
 import { FOOTER_CLASSNAME } from "../../../common/constants";
 import { Footer } from "../..";
 
@@ -13,27 +14,82 @@ describe("Footer modifiers", () => {
 	it("should render a default footer", async () => {
 		render(<Footer />);
 		const footer = await screen.findByRole("contentinfo");
-		expect(footer.className).toContain("text-center");
-		expect(footer.className).toContain(FOOTER_CLASSNAME);
+		expectToHaveClasses(footer, [
+			FOOTER_CLASSNAME,
+			"text-center",
+			"text-xs",
+			"text-copy-dark",
+			"mb-[100px]",
+			"mt-0",
+			"flex",
+			"w-full",
+			"flex-col",
+			"p-2",
+			"sm:mt-3",
+			"md:mx-auto",
+			"md:max-w-4xl",
+		]);
 	});
 
 	it("should render a dark footer", async () => {
 		render(<Footer kind="dark" />);
 		const footer = await screen.findByRole("contentinfo");
-		expect(footer.className).toContain("text-copy-dark");
+		expectToHaveClasses(footer, [
+			FOOTER_CLASSNAME,
+			"text-center",
+			"text-xs",
+			"text-copy-dark",
+			"mb-[100px]",
+			"mt-0",
+			"flex",
+			"w-full",
+			"flex-col",
+			"p-2",
+			"sm:mt-3",
+			"md:mx-auto",
+			"md:max-w-4xl",
+		]);
 	});
 
 	it("should render a light footer", async () => {
 		render(<Footer kind="light" />);
 		const footer = await screen.findByRole("contentinfo");
-		expect(footer.className).toContain("text-copy-light");
+		expectToHaveClasses(footer, [
+			FOOTER_CLASSNAME,
+			"text-center",
+			"text-xs",
+			"text-copy-light",
+			"mb-[100px]",
+			"mt-0",
+			"flex",
+			"w-full",
+			"flex-col",
+			"p-2",
+			"sm:mt-3",
+			"md:mx-auto",
+			"md:max-w-4xl",
+		]);
 	});
 
 	it("should render a footer with a custom class", async () => {
 		render(<Footer className="toto" />);
 		const footer = await screen.findByRole("contentinfo");
-		expect(footer.className).toContain("text-center");
-		expect(footer.className).toContain("toto");
+		expectToHaveClasses(footer, [
+			FOOTER_CLASSNAME,
+			"text-center",
+			"text-xs",
+			"text-copy-dark",
+			"mb-[100px]",
+			"mt-0",
+			"flex",
+			"w-full",
+			"flex-col",
+			"p-2",
+			"sm:mt-3",
+			"md:mx-auto",
+			"md:max-w-4xl",
+			"toto",
+		]);
 	});
 
 	it("should render a footer with one row (row1)", async () => {
@@ -60,5 +116,63 @@ describe("Footer modifiers", () => {
 		expect(row1).toBeDefined();
 		const row2 = await screen.findByText("row2");
 		expect(row2).toBeDefined();
+	});
+
+	it("should render a footer with no margins", async () => {
+		render(<Footer noMargins />);
+		const footer = await screen.findByRole("contentinfo");
+		expectToHaveClasses(footer, [
+			FOOTER_CLASSNAME,
+			"text-center",
+			"text-xs",
+			"text-copy-dark",
+			"mt-0",
+			"flex",
+			"w-full",
+			"flex-col",
+			"p-2",
+			"sm:mt-3",
+			"md:mx-auto",
+			"md:max-w-4xl",
+		]);
+		expect(footer.className).not.toContain("mb-[100px]");
+	});
+
+	it("should render a footer with no margins with deprecated prop", async () => {
+		render(<Footer noPaddings />);
+		const footer = await screen.findByRole("contentinfo");
+		expectToHaveClasses(footer, [
+			FOOTER_CLASSNAME,
+			"text-center",
+			"text-xs",
+			"text-copy-dark",
+			"mt-0",
+			"flex",
+			"w-full",
+			"flex-col",
+			"p-2",
+			"sm:mt-3",
+			"md:mx-auto",
+			"md:max-w-4xl",
+		]);
+		expect(footer.className).not.toContain("mb-[100px]");
+	});
+
+	it("should render a raw footer", async () => {
+		render(<Footer raw />);
+		const footer = await screen.findByRole("contentinfo");
+		expect(footer.className).toContain(FOOTER_CLASSNAME);
+		expect(footer.className).not.toContain("text-center");
+		expect(footer.className).not.toContain("text-xs");
+		expect(footer.className).not.toContain("text-copy-dark");
+		expect(footer.className).not.toContain("mt-0");
+		expect(footer.className).not.toContain("flex");
+		expect(footer.className).not.toContain("w-full");
+		expect(footer.className).not.toContain("flex-col");
+		expect(footer.className).not.toContain("p-2");
+		expect(footer.className).not.toContain("sm:mt-3");
+		expect(footer.className).not.toContain("md:mx-auto");
+		expect(footer.className).not.toContain("md:max-w-4xl");
+		expect(footer.className).not.toContain("mb-[100px]");
 	});
 });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new "test:coverage" script for enhanced testing capabilities.
	- Enhanced the Footer component with new properties (`noMargins`, `raw`) for greater flexibility in styling and layout.
	- Added a new story in the documentation showcasing the Footer component with the Main component.

- **Documentation**
	- Updated Footer component documentation to reflect new properties and deprecated ones.

- **Tests**
	- Added and refactored tests for the Footer component to cover new functionalities and properties.

- **Refactor**
	- Deprecated `noPaddings` property in favor of `noMargins` for the Footer component, aligning with updated styling conventions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->