### PR TITLE
feat(Icons): icons should be decorative by default

### DIFF
--- a/packages/documentation/.ladle/components.tsx
+++ b/packages/documentation/.ladle/components.tsx
@@ -53,7 +53,7 @@ export const Provider: GlobalProvider = ({ children, storyMeta }) => {
 						label="link to UI Components GitHub repository"
 						onClick={handleOnClickGitHub}
 					>
-						<IconGitHub decorative />
+						<IconGitHub />
 					</ButtonIcon>
 				}
 				row2={

--- a/packages/documentation/src/System/Icons.stories.tsx
+++ b/packages/documentation/src/System/Icons.stories.tsx
@@ -57,5 +57,6 @@ export const Basic: Story<any> = (args) => (
 
 Basic.args = {
 	monotone: false,
-	decorative: true,
+	semantic: false,
+	// decorative: true,
 };

--- a/packages/documentation/src/System/Icons.stories.tsx
+++ b/packages/documentation/src/System/Icons.stories.tsx
@@ -58,5 +58,4 @@ export const Basic: Story<any> = (args) => (
 Basic.args = {
 	monotone: false,
 	semantic: false,
-	// decorative: true,
 };

--- a/packages/ui-components/src/components/Bubble/Bubble.tsx
+++ b/packages/ui-components/src/components/Bubble/Bubble.tsx
@@ -73,7 +73,7 @@ export const Bubble = ({
 						onClick={handleCopyToClipboard}
 						disabled={copied}
 					>
-						{copied ? <IconCopied decorative /> : <IconCopy decorative />}
+						{copied ? <IconCopied /> : <IconCopy />}
 					</ButtonIcon>
 				</div>
 			)}

--- a/packages/ui-components/src/components/Button/__tests__/ButtonIcon.test.tsx
+++ b/packages/ui-components/src/components/Button/__tests__/ButtonIcon.test.tsx
@@ -100,7 +100,7 @@ describe("ButtonIcon modifiers", () => {
 	it("should render a size small button icon with a label on the right", async () => {
 		render(
 			<ButtonIcon size="small" labelRight="Settings">
-				<IconSettings decorative />
+				<IconSettings />
 			</ButtonIcon>,
 		);
 		const button = await screen.findByRole("button");
@@ -112,7 +112,7 @@ describe("ButtonIcon modifiers", () => {
 	it("should render a size small button icon with a label on the left", async () => {
 		render(
 			<ButtonIcon size="small" labelLeft="Settings">
-				<IconSettings decorative />
+				<IconSettings />
 			</ButtonIcon>,
 		);
 		const button = await screen.findByRole("button");
@@ -134,7 +134,7 @@ describe("ButtonIcon modifiers", () => {
 	it("should render a size medium button icon with a label on the right", async () => {
 		render(
 			<ButtonIcon size="medium" labelRight="Settings">
-				<IconSettings decorative />
+				<IconSettings />
 			</ButtonIcon>,
 		);
 		const button = await screen.findByRole("button");
@@ -146,7 +146,7 @@ describe("ButtonIcon modifiers", () => {
 	it("should render a size medium button icon with a label on the left", async () => {
 		render(
 			<ButtonIcon size="medium" labelLeft="Settings">
-				<IconSettings decorative />
+				<IconSettings />
 			</ButtonIcon>,
 		);
 		const button = await screen.findByRole("button");
@@ -168,7 +168,7 @@ describe("ButtonIcon modifiers", () => {
 	it("should render a size large button icon with a label on the right", async () => {
 		render(
 			<ButtonIcon size="large" labelRight="Settings">
-				<IconSettings decorative />
+				<IconSettings />
 			</ButtonIcon>,
 		);
 		const button = await screen.findByRole("button");
@@ -180,7 +180,7 @@ describe("ButtonIcon modifiers", () => {
 	it("should render a size large button icon with a label on the left", async () => {
 		render(
 			<ButtonIcon size="large" labelLeft="Settings">
-				<IconSettings decorative />
+				<IconSettings />
 			</ButtonIcon>,
 		);
 		const button = await screen.findByRole("button");

--- a/packages/ui-icons/src/components/Icons/IconsTypes.d.ts
+++ b/packages/ui-icons/src/components/Icons/IconsTypes.d.ts
@@ -4,12 +4,6 @@ export interface IconsProps
 	extends Omit<React.SVGAttributes<SVGElement>, "spacing">,
 		SpacingProps {
 	/**
-	 * Whether or not the icon is decorative only (visual but not
-	 * announced to assistive technologies).
-	 * @default false
-	 */
-	decorative?: boolean;
-	/**
 	 * Whether or not to render the icon in a single color
 	 * @default false
 	 */
@@ -19,4 +13,10 @@ export interface IconsProps
 	 * but it can be overridden with this prop.
 	 */
 	title?: string;
+	/**
+	 * Whether or not the icon is semantic (visual and
+	 * announced to assistive technologies).
+	 * @default false
+	 */
+	semantic?: boolean;
 }

--- a/packages/ui-private/src/components/SvgIcon/SvgIcon.tsx
+++ b/packages/ui-private/src/components/SvgIcon/SvgIcon.tsx
@@ -12,7 +12,7 @@ export const SvgIcon = ({
 	defaultClassName,
 	spacing,
 	title,
-	decorative = false,
+	semantic = false,
 	...rest
 }: SvgIconProps) => {
 	const generatedSpacing = getSpacing(spacing);
@@ -28,13 +28,13 @@ export const SvgIcon = ({
 				viewBox={viewBox ? viewBox : defaultViewBox}
 				fill={fill ? fill : "currentColor"}
 				role="img"
-				aria-hidden={decorative}
+				aria-hidden={!semantic}
 				focusable={false}
 				{...rest}
 			>
 				{children}
 			</svg>
-			{title && !decorative && <span className="sr-only">{title}</span>}
+			{title && semantic && <span className="sr-only">{title}</span>}
 		</>
 	);
 };

--- a/packages/ui-private/src/components/SvgIcon/SvgIconTypes.d.ts
+++ b/packages/ui-private/src/components/SvgIcon/SvgIconTypes.d.ts
@@ -19,12 +19,6 @@ export type SvgIconProps = {
 	 */
 	className?: string;
 	/**
-	 * Whether or not the icon is decorative only (visual but not
-	 * announced to assistive technologies).
-	 * @default false
-	 */
-	decorative?: boolean;
-	/**
 	 * CSS class(es) to add to the main component wrapper.
 	 */
 	defaultClassName?: string;
@@ -33,6 +27,12 @@ export type SvgIconProps = {
 	 * @default "currentColor"
 	 */
 	fill?: string;
+	/**
+	 * Whether or not the icon is semantic (visual and
+	 * announced to assistive technologies).
+	 * @default false
+	 */
+	semantic?: boolean;
 	/**
 	 * The viewBox to use. If not provided, the default viewBox will be used.
 	 */

--- a/packages/ui-private/src/components/SvgIcon/__tests__/SvgIcon.test.tsx
+++ b/packages/ui-private/src/components/SvgIcon/__tests__/SvgIcon.test.tsx
@@ -47,4 +47,35 @@ describe("SvgIcon prop tests", () => {
 		const svg = await screen.findByTestId("svgicon-1");
 		expect(svg.getAttribute("class")).toBe("toto");
 	});
+
+	it("should render a decorative icon by default", async () => {
+		render(
+			<SvgIcon
+				data-testid="svgicon-1"
+				defaultViewBox="0 0 448 512"
+				viewBox="0 0 666 666"
+				title="toto"
+			>
+				<path d="M8 256a56 56 0 1 1 112 0A56 56 0 1 1 8 256zm160 0a56 56 0 1 1 112 0 56 56 0 1 1 -112 0zm216-56a56 56 0 1 1 0 112 56 56 0 1 1 0-112z" />
+			</SvgIcon>,
+		);
+		const svg = await screen.findByTestId("svgicon-1");
+		expect(svg.getAttribute("aria-hidden")).toBe("true");
+	});
+
+	it("should honor the `semantic` prop", async () => {
+		render(
+			<SvgIcon
+				data-testid="svgicon-1"
+				defaultViewBox="0 0 448 512"
+				viewBox="0 0 666 666"
+				title="toto"
+				semantic
+			>
+				<path d="M8 256a56 56 0 1 1 112 0A56 56 0 1 1 8 256zm160 0a56 56 0 1 1 112 0 56 56 0 1 1 -112 0zm216-56a56 56 0 1 1 0 112 56 56 0 1 1 0-112z" />
+			</SvgIcon>,
+		);
+		const svg = await screen.findByTestId("svgicon-1");
+		expect(svg.getAttribute("aria-hidden")).toBe("false");
+	});
 });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced accessibility by introducing a `semantic` property for icons, replacing the `decorative` property. This update ensures a clearer differentiation between decorative and semantic icons, improving support for assistive technologies.

- **Refactor**
	- Renamed `decorative` prop to `semantic` across components, adjusting logic to align with accessibility enhancements.

- **Tests**
	- Added tests to validate correct icon rendering based on the `semantic` property, ensuring icons are properly announced by assistive technologies as needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->