### PR TITLE
docs: update icons deprecated prop

### DIFF
--- a/packages/documentation/src/Components/ButtonIcon.stories.tsx
+++ b/packages/documentation/src/Components/ButtonIcon.stories.tsx
@@ -28,38 +28,38 @@ export const WithLabel: Story<any> = (args) => (
 	<>
 		<div className="flex flex-wrap">
 			<ButtonIcon labelRight="Settings" {...args}>
-				<IconSettings decorative />
+				<IconSettings />
 			</ButtonIcon>
 			<ButtonIcon labelRight="Settings" {...args}>
-				<IconSettings decorative />
+				<IconSettings />
 			</ButtonIcon>
 			<ButtonIcon labelRight="Edit" {...args}>
-				<IconEdit decorative className="h-3 w-3" />
+				<IconEdit className="h-3 w-3" />
 			</ButtonIcon>
 			<ButtonIcon labelRight="Edit" {...args}>
-				<IconEdit decorative />
+				<IconEdit />
 			</ButtonIcon>
 		</div>
 		<div className="mt-2 flex flex-wrap">
 			<ButtonIcon labelLeft="Settings" {...args}>
-				<IconSettings decorative />
+				<IconSettings />
 			</ButtonIcon>
 			<ButtonIcon labelLeft="Settings" {...args}>
-				<IconSettings decorative />
+				<IconSettings />
 			</ButtonIcon>
 			<ButtonIcon labelLeft="Edit" {...args}>
-				<IconEdit decorative className="h-3 w-3" />
+				<IconEdit className="h-3 w-3" />
 			</ButtonIcon>
 			<ButtonIcon labelLeft="Edit" {...args}>
-				<IconEdit decorative />
+				<IconEdit />
 			</ButtonIcon>
 		</div>
 		<div className="mt-2 flex flex-wrap">
 			<ButtonIcon labelRight="Previous page" {...args}>
-				<IconPrevious decorative monotone />
+				<IconPrevious monotone />
 			</ButtonIcon>
 			<ButtonIcon labelLeft="Next page" {...args}>
-				<IconNext decorative monotone />
+				<IconNext monotone />
 			</ButtonIcon>
 		</div>
 	</>

--- a/packages/documentation/src/Components/Menu.stories.tsx
+++ b/packages/documentation/src/Components/Menu.stories.tsx
@@ -73,10 +73,10 @@ export const WithIcons: Story<any> = (args) => (
 			Button
 		</Button>
 		<Menu icon={<IconSettings />} spacing={{ r: 2 }} {...args}>
-			<MenuItem label="Profile" icon={<IconProfile decorative />} />
-			<MenuItem label="Statistics" icon={<IconChart decorative />} />
-			<MenuItem label="History" icon={<IconHistory decorative />} />
-			<MenuItem label="About" icon={<IconInfo decorative />} />
+			<MenuItem label="Profile" icon={<IconProfile />} />
+			<MenuItem label="Statistics" icon={<IconChart />} />
+			<MenuItem label="History" icon={<IconHistory />} />
+			<MenuItem label="About" icon={<IconInfo />} />
 		</Menu>
 		<Button size="small">Button</Button>
 	</div>
@@ -118,17 +118,17 @@ export const WithMessageBox: Story<any> = (args) => {
 					Button
 				</Button>
 				<Menu icon={<IconSettings />} spacing={{ r: 2 }} {...args}>
-					<MenuItem label="Profile" icon={<IconProfile decorative />} />
-					<MenuItem label="Statistics" icon={<IconChart decorative />} />
-					<MenuItem label="History" icon={<IconHistory decorative />} />
-					<MenuItem label="About" icon={<IconInfo decorative />} />
+					<MenuItem label="Profile" icon={<IconProfile />} />
+					<MenuItem label="Statistics" icon={<IconChart />} />
+					<MenuItem label="History" icon={<IconHistory />} />
+					<MenuItem label="About" icon={<IconInfo />} />
 					<MenuSeparator />
 					<MenuItem
 						onClick={handleMenuLogout}
 						label="Log out"
 						icon={
 							<div className="text-red-700">
-								<IconBack decorative monotone />
+								<IconBack monotone />
 							</div>
 						}
 					/>

--- a/packages/documentation/src/GettingStarted/1-overview.stories.tsx
+++ b/packages/documentation/src/GettingStarted/1-overview.stories.tsx
@@ -26,7 +26,7 @@ export const Overview: Story<any> = () => (
 					noBorder
 					onClick={linkTo("getting-started--installation")}
 				>
-					<IconNext decorative monotone />
+					<IconNext monotone />
 				</ButtonIcon>
 			</FlexgridItem>
 			<FlexgridItem span={{ fallback: 12, lg: 6 }}>

--- a/packages/documentation/src/GettingStarted/2-Installation.stories.tsx
+++ b/packages/documentation/src/GettingStarted/2-Installation.stories.tsx
@@ -29,7 +29,7 @@ export const Installation: Story<any> = () => (
 					noBorder
 					onClick={linkTo("getting-started--overview")}
 				>
-					<IconPrevious decorative monotone />
+					<IconPrevious monotone />
 				</ButtonIcon>
 			</FlexgridItem>
 			<FlexgridItem>
@@ -38,7 +38,7 @@ export const Installation: Story<any> = () => (
 					noBorder
 					onClick={linkTo("getting-started--configuration")}
 				>
-					<IconNext decorative monotone />
+					<IconNext monotone />
 				</ButtonIcon>
 			</FlexgridItem>
 		</Flexgrid>

--- a/packages/documentation/src/GettingStarted/3-configuration.stories.tsx
+++ b/packages/documentation/src/GettingStarted/3-configuration.stories.tsx
@@ -87,7 +87,7 @@ export default twPlugin.merge({
 					noBorder
 					onClick={linkTo("getting-started--installation")}
 				>
-					<IconPrevious decorative monotone />
+					<IconPrevious monotone />
 				</ButtonIcon>
 			</FlexgridItem>
 			<FlexgridItem>
@@ -96,7 +96,7 @@ export default twPlugin.merge({
 					noBorder
 					onClick={linkTo("getting-started--usage")}
 				>
-					<IconNext decorative monotone />
+					<IconNext monotone />
 				</ButtonIcon>
 			</FlexgridItem>
 		</Flexgrid>

--- a/packages/documentation/src/GettingStarted/4-usage.stories.mdx
+++ b/packages/documentation/src/GettingStarted/4-usage.stories.mdx
@@ -57,7 +57,7 @@ function App() {
 				noBorder
 				onClick={linkTo("getting-started--configuration")}
 			>
-				<IconPrevious decorative monotone />
+				<IconPrevious monotone />
 			</ButtonIcon>
 		</FlexgridItem>
 		<FlexgridItem>
@@ -66,7 +66,7 @@ function App() {
 				noBorder
 				onClick={linkTo("getting-started--release-tags")}
 			>
-				<IconNext decorative monotone />
+				<IconNext monotone />
 			</ButtonIcon>
 		</FlexgridItem>
 	</Flexgrid>

--- a/packages/documentation/src/GettingStarted/5-alpha-beta.stories.tsx
+++ b/packages/documentation/src/GettingStarted/5-alpha-beta.stories.tsx
@@ -76,7 +76,7 @@ export const ReleaseTags: Story<any> = () => (
 						noBorder
 						onClick={linkTo("getting-started--usage")}
 					>
-						<IconPrevious decorative monotone />
+						<IconPrevious monotone />
 					</ButtonIcon>
 				</FlexgridItem>
 			</Flexgrid>

--- a/packages/documentation/src/System/DarkMode.stories.tsx
+++ b/packages/documentation/src/System/DarkMode.stories.tsx
@@ -93,11 +93,11 @@ module.exports = {
 				</Anchor>
 			</div>
 			<div className="mb-2 flex flex-wrap justify-end gap-1">
-				<Menu icon={<IconSettings decorative />} kind="system">
-					<MenuItem label="Profile" icon={<IconProfile decorative />} />
-					<MenuItem label="Statistics" icon={<IconChart decorative />} />
-					<MenuItem label="History" icon={<IconHistory decorative />} />
-					<MenuItem label="About" icon={<IconInfo decorative />} />
+				<Menu icon={<IconSettings />} kind="system">
+					<MenuItem label="Profile" icon={<IconProfile />} />
+					<MenuItem label="Statistics" icon={<IconChart />} />
+					<MenuItem label="History" icon={<IconHistory />} />
+					<MenuItem label="About" icon={<IconInfo />} />
 				</Menu>
 			</div>
 			<form noValidate>
@@ -147,7 +147,7 @@ module.exports = {
 												kind="light"
 												onClick={() => {}}
 											>
-												<IconRestore decorative className="h-3 w-3" />
+												<IconRestore className="h-3 w-3" />
 											</ButtonIcon>
 											<ButtonIcon
 												noBorder
@@ -156,7 +156,7 @@ module.exports = {
 												onClick={() => {}}
 											>
 												<div className="text-red-400">
-													<IconDelete decorative className="h-3 w-3" monotone />
+													<IconDelete className="h-3 w-3" monotone />
 												</div>
 											</ButtonIcon>
 										</div>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated various components in the documentation to refine icon usage, specifically removing the `decorative` prop for a clearer, more consistent visual presentation.
	- Introduced a `MenuSeparator` in the `Menu` component for better visual organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->