### PR TITLE
feat(Modal): adding prop className to ModalClose

### DIFF
--- a/packages/ui-private/src/components/Modal/Modal.tsx
+++ b/packages/ui-private/src/components/Modal/Modal.tsx
@@ -107,18 +107,19 @@ export const ModalClose = React.forwardRef<
 	HTMLButtonElement,
 	{
 		trigger: React.ReactElement;
+		className?: string;
 	}
 >(function ModalClose(props, ref) {
 	const { setOpen } = useModalContext();
-	const { trigger, ...rest } = props;
+	const { trigger, className, ...rest } = props;
 	const handleClose = React.useCallback(() => setOpen(false), [setOpen]);
 	return (
-		<>
+		<div className={className}>
 			{React.cloneElement(trigger, {
 				ref,
 				onClick: handleClose,
 				...rest,
 			})}
-		</>
+		</div>
 	);
 });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Enhanced the styling capability of the modal close component by introducing a class name property.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->