### PR TITLE
docs: fix focus mode for inline button

### DIFF
--- a/packages/documentation/src/System/DarkMode.stories.tsx
+++ b/packages/documentation/src/System/DarkMode.stories.tsx
@@ -156,7 +156,7 @@ module.exports = {
 												noBorder
 												label="Restore chat"
 												mode="light"
-												focus="alt-system"
+												focusMode="alt-system"
 												onClick={() => {}}
 											>
 												<IconRestore className="h-3 w-3" />
@@ -165,7 +165,7 @@ module.exports = {
 												noBorder
 												label="Delete chat"
 												mode="light"
-												focus="alt-system"
+												focusMode="alt-system"
 												onClick={() => {}}
 											>
 												<div className="text-red-400">


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Renamed the `focus` prop to `focusMode` for clarity in the "Restore chat" and "Delete chat" buttons within stories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->