### PR TITLE
feat(Card): adding prop bodyClassName

### DIFF
--- a/packages/documentation/src/GettingStarted/6-changelogs.stories.mdx
+++ b/packages/documentation/src/GettingStarted/6-changelogs.stories.mdx
@@ -14,7 +14,7 @@ import SystemChangelog from "../../../ui-system/CHANGELOG.md";
 
 <details>
 	<summary>Components</summary>
-	<Card bodyClassName="text-copy-lighter">
+	<Card>
 		<ComponentsChangelog />
 	</Card>
 </details>

--- a/packages/documentation/src/GettingStarted/6-changelogs.stories.mdx
+++ b/packages/documentation/src/GettingStarted/6-changelogs.stories.mdx
@@ -14,7 +14,7 @@ import SystemChangelog from "../../../ui-system/CHANGELOG.md";
 
 <details>
 	<summary>Components</summary>
-	<Card>
+	<Card bodyClassName="text-copy-lighter">
 		<ComponentsChangelog />
 	</Card>
 </details>

--- a/packages/ui-components/src/components/Card/Card.tsx
+++ b/packages/ui-components/src/components/Card/Card.tsx
@@ -35,6 +35,7 @@ export const Card = ({
 	footerClassName,
 	children,
 	className,
+	bodyClassName,
 	"aria-labelledby": ariaLabelledby,
 	spacing,
 	mode = "system",
@@ -50,6 +51,7 @@ export const Card = ({
 	const cardClassName = getCardClasses({
 		className,
 		headerClassName,
+		bodyClassName,
 		footerClassName,
 		spacing,
 		mode,
@@ -97,6 +99,7 @@ export const Card = ({
 				{...(sectionAriaLabelledBy && {
 					"aria-labelledby": sectionAriaLabelledBy,
 				})}
+				className={cardClassName.body}
 				{...otherProps}
 			>
 				<CardHeader

--- a/packages/ui-components/src/components/Card/CardTypes.d.ts
+++ b/packages/ui-components/src/components/Card/CardTypes.d.ts
@@ -12,7 +12,12 @@ export type CardProps = {
 	 */
 	"aria-labelledby"?: string;
 	/**
-	 * CSS class(es) to add to the main component wrapper.
+	 * CSS class(es) to add to the body.
+	 */
+	bodyClassName?: string;
+	/**
+	 * CSS class(es) to add to the main component wrapper. If provided,
+	 * it overrides the default styles.
 	 */
 	className?: string;
 	/**

--- a/packages/ui-components/src/components/Card/__tests__/Card.test.tsx
+++ b/packages/ui-components/src/components/Card/__tests__/Card.test.tsx
@@ -94,6 +94,17 @@ describe("Card modifiers", () => {
 		expectToHaveClasses(header, ["toto-header"]);
 	});
 
+	it("should render a card with a custom body class", async () => {
+		render(<Card bodyClassName="toto-body">{cardContent}</Card>);
+		const body = await screen.findByText(cardContent);
+		expect(body).toBeDefined();
+
+		const parent = body.parentElement;
+		if (parent) {
+			expectToHaveClasses(parent, ["toto-body"]);
+		}
+	});
+
 	it("should render a card with a custom footer class", async () => {
 		render(
 			<Card footer="hello" footerClassName="toto-footer">

--- a/packages/ui-components/src/components/Card/utilities.ts
+++ b/packages/ui-components/src/components/Card/utilities.ts
@@ -5,6 +5,7 @@ import clsx from "clsx";
 import { CARD_CLASSNAME } from "../../common/constants";
 
 type getCardClassesProps = {
+	bodyClassName?: string;
 	className?: string;
 	footerClassName?: string;
 	headerClassName?: string;
@@ -14,6 +15,7 @@ type getCardClassesProps = {
 export const getCardClasses = ({
 	className,
 	headerClassName,
+	bodyClassName,
 	footerClassName,
 	spacing,
 	mode,
@@ -36,6 +38,7 @@ export const getCardClasses = ({
 				`${CARD_CLASSNAME}__header not-prose mb-4 border-b-2 border-border-medium text-lg font-bold`,
 			);
 
+	const body = clsx(bodyClassName);
 	const footer = footerClassName
 		? footerClassName
 		: clsx(`${CARD_CLASSNAME}__footer pt-2`);
@@ -43,6 +46,7 @@ export const getCardClasses = ({
 	return {
 		wrapper,
 		header,
+		body,
 		footer,
 	};
 };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new `bodyClassName` property for the `Card` component to allow custom styling of the card's body.
- **Tests**
	- Added a test to verify custom body class functionality in the `Card` component.
- **Documentation**
	- Updated the Getting Started guide to reflect the new `bodyClassName` property usage in the `Card` component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->