### PR TITLE
docs: re-order styles section

### DIFF
--- a/packages/documentation/.ladle/config.mjs
+++ b/packages/documentation/.ladle/config.mjs
@@ -12,6 +12,7 @@ export default {
 		"Components*",
 		"Form-components*",
 		"Icons*",
+		"styles--typography--quick-start",
 		"Styles*",
 		"System*",
 	],

--- a/packages/documentation/src/Styles/DarkMode.stories.tsx
+++ b/packages/documentation/src/Styles/DarkMode.stories.tsx
@@ -25,7 +25,7 @@ import {
 	IconSettings,
 } from "@versini/ui-icons";
 
-export default { title: "Styles/Dark Mode" };
+export default { title: "Styles/Components" };
 
 const data = [
 	{
@@ -198,7 +198,7 @@ module.exports = {
 	);
 };
 
-export const Automatic: Story<any> = () => (
+export const DarkMode: Story<any> = () => (
 	<Card>
 		<h1>Automatic Dark Mode</h1>
 		<CommonTemplate />


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the documentation to include a new "Quick Start" section under "Typography."
- **Refactor**
	- Renamed the "Dark Mode" story to "Components" and updated the export name for clarity in the documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->