### PR TITLE
fix(Anchor): [a11y] replace `div` with `span` as `div` cannot be placed in `p`

### DIFF
--- a/packages/ui-components/src/components/Button/ButtonLink.tsx
+++ b/packages/ui-components/src/components/Button/ButtonLink.tsx
@@ -58,9 +58,9 @@ export const ButtonLink = React.forwardRef<HTMLAnchorElement, ButtonLinkProps>(
 				href={link}
 				{...extraProps}
 			>
-				<div {...(!noTruncate && { className: "truncate" })}>
+				<span {...(!noTruncate && { className: "truncate" })}>
 					{formattedLabel?.truncatedString || children}
-				</div>
+				</span>
 			</a>
 		);
 	},


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated the `ButtonLink` component for improved label rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->