### PR TITLE
docs: use system mode for Table used in Flexgrid example

### DIFF
--- a/packages/documentation/src/System/Flexgrid.stories.tsx
+++ b/packages/documentation/src/System/Flexgrid.stories.tsx
@@ -200,7 +200,7 @@ export const Responsive: Story<any> = (args) => {
 	return (
 		<>
 			<p className="text-copy-lighter">{intro}</p>
-			<Table mode="light" spacing={{ t: 2, b: 2 }}>
+			<Table>
 				<TableHead>
 					<TableRow>
 						<TableCell>Breakpoint prefix</TableCell>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Simplified the `<Table>` component usage in the Flexgrid documentation by removing the `spacing` prop.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->