### PR TITLE
fix(Menu): no way to update focusMode

### DIFF
--- a/packages/documentation/src/Components/Menu.stories.tsx
+++ b/packages/documentation/src/Components/Menu.stories.tsx
@@ -23,13 +23,19 @@ export default {
 	},
 	args: {
 		mode: "system",
+		focusMode: "system",
 		defaultPlacement: "bottom-start",
 	},
 	argTypes: {
+		focusMode: {
+			control: { type: "radio" },
+			options: ["dark", "light", "system", "alt-system"],
+		},
 		mode: {
 			control: { type: "radio" },
 			options: ["dark", "light", "system", "alt-system"],
 		},
+
 		defaultPlacement: {
 			control: { type: "select" },
 			options: [
@@ -98,7 +104,7 @@ export const WithMessageBox: Story<any> = (args) => {
 	return (
 		<>
 			<Panel
-				mode="messagebox"
+				kind="messagebox"
 				open={showMessage}
 				onOpenChange={setShowMessage}
 				title="Log out"

--- a/packages/ui-components/src/components/Menu/Menu.tsx
+++ b/packages/ui-components/src/components/Menu/Menu.tsx
@@ -39,6 +39,7 @@ export const MenuComponent = forwardRef<
 			onOpenChange,
 			spacing,
 			mode = "system",
+			focusMode = "system",
 			...props
 		},
 		userRef,
@@ -122,6 +123,7 @@ export const MenuComponent = forwardRef<
 			<FloatingNode id={nodeId}>
 				<ButtonIcon
 					mode={mode}
+					focusMode={focusMode}
 					spacing={spacing}
 					label={label || "Open menu"}
 					ref={useMergeRefs([refs.setReference, item.ref, userRef])}

--- a/packages/ui-components/src/components/Menu/MenuTypes.d.ts
+++ b/packages/ui-components/src/components/Menu/MenuTypes.d.ts
@@ -12,6 +12,11 @@ export interface MenuProps extends SpacingProps {
 	 */
 	defaultPlacement?: Placement;
 	/**
+	 * The type of focus for the Button. This will change the color
+	 * of the focus ring around the Button.
+	 */
+	focusMode?: "dark" | "light" | "system" | "alt-system";
+	/**
 	 * A React component of type Icon to be placed on the left of the label.
 	 */
 	icon?: React.ReactNode;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new `focusMode` option for the `Menu` component to customize focus ring color.
- **Refactor**
	- Changed the `mode` property to `kind` in the `Panel` component for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->