### PR TITLE
feat(Bubble): adding modes for copy-to-clipboard button

### DIFF
--- a/packages/documentation/src/Components/Bubble.stories.tsx
+++ b/packages/documentation/src/Components/Bubble.stories.tsx
@@ -174,3 +174,18 @@ export const Copy: Story<any> = (args) => {
 		</div>
 	);
 };
+
+Copy.args = {
+	copyToClipboardMode: "system",
+	copyToClipboardFocusMode: "system",
+};
+Copy.argTypes = {
+	copyToClipboardMode: {
+		options: ["dark", "light", "system", "alt-system"],
+		control: { type: "radio" },
+	},
+	copyToClipboardFocusMode: {
+		options: ["dark", "light", "system", "alt-system"],
+		control: { type: "radio" },
+	},
+};

--- a/packages/ui-components/src/components/Bubble/Bubble.tsx
+++ b/packages/ui-components/src/components/Bubble/Bubble.tsx
@@ -12,6 +12,8 @@ export const Bubble = ({
 	footer,
 	rawFooter,
 	copyToClipboard,
+	copyToClipboardFocusMode = "system",
+	copyToClipboardMode = "system",
 	spacing,
 }: BubbleProps) => {
 	const [copied, setCopied] = useState(false);
@@ -68,8 +70,8 @@ export const Bubble = ({
 			{isCopyToClipboardEnabled && (
 				<div className={bubbleClasses.copyButton}>
 					<ButtonIcon
-						mode="system"
-						focusMode="system"
+						mode={copyToClipboardMode}
+						focusMode={copyToClipboardFocusMode}
 						label={copied ? "Copied to clipboard" : "Copy to clipboard"}
 						noBorder
 						noBackground

--- a/packages/ui-components/src/components/Bubble/BubbleTypes.d.ts
+++ b/packages/ui-components/src/components/Bubble/BubbleTypes.d.ts
@@ -14,6 +14,15 @@ export type BubbleProps = {
 	 */
 	copyToClipboard?: boolean | string | ((text: any) => void);
 	/**
+	 * The type of focus for the Copy Button. This will change the color
+	 * of the focus ring around the Button.
+	 */
+	copyToClipboardFocusMode?: "dark" | "light" | "system" | "alt-system";
+	/**
+	 * The mode of Copy Button. This will change the color of the Button.
+	 */
+	copyToClipboardMode?: "dark" | "light" | "system" | "alt-system";
+	/**
 	 * Object depicting the extra rows for the Bubble.
 	 * @example
 	 * ```tsx

--- a/packages/ui-components/src/components/Bubble/__tests__/Bubble.test.tsx
+++ b/packages/ui-components/src/components/Bubble/__tests__/Bubble.test.tsx
@@ -4,7 +4,7 @@ import { act, fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import { expectToHaveClasses } from "../../../../../../configuration/tests-helpers";
-import { BUBBLE_CLASSNAME } from "../../../common/constants";
+import { BUBBLE_CLASSNAME, BUTTON_CLASSNAME } from "../../../common/constants";
 import { Bubble } from "../..";
 
 describe("Bubble (exceptions)", () => {
@@ -195,6 +195,152 @@ describe("Bubble modifiers", () => {
 			"text-start",
 			"text-xs",
 			"text-red-500",
+		]);
+	});
+
+	it("should render a default (system) copy button", async () => {
+		render(
+			<Bubble kind="left" copyToClipboard>
+				hello
+			</Bubble>,
+		);
+		await screen.findByText("hello");
+		await screen.findByLabelText("Copy to clipboard");
+		const button = await screen.findByRole("button");
+		expect(button).toBeInTheDocument();
+		expectToHaveClasses(button, [
+			BUTTON_CLASSNAME,
+			"active:bg-action-dark-active",
+			"active:text-copy-light-active",
+			"border-transparent",
+			"border",
+			"dark:active:bg-action-light-active",
+			"dark:focus:outline-focus-light",
+			"dark:hover:bg-action-light-hover",
+			"focus:outline-2",
+			"focus:outline-focus-dark",
+			"focus:outline-offset-2",
+			"focus:outline",
+			"h-8",
+			"hover:bg-action-dark-hover",
+			"hover:text-copy-light-hover",
+			"inline-flex",
+			"items-center",
+			"justify-center",
+			"not-prose",
+			"p-1",
+			"rounded-full",
+			"w-8",
+		]);
+	});
+
+	it("should render a light copy button", async () => {
+		render(
+			<Bubble kind="left" copyToClipboard copyToClipboardMode="light">
+				hello
+			</Bubble>,
+		);
+		await screen.findByText("hello");
+		await screen.findByLabelText("Copy to clipboard");
+		const button = await screen.findByRole("button");
+		expect(button).toBeInTheDocument();
+		expectToHaveClasses(button, [
+			BUTTON_CLASSNAME,
+			"active:bg-action-light-active",
+			"active:text-copy-light-active",
+			"border-transparent",
+			"border",
+			"dark:focus:outline-focus-light",
+			"focus:outline-2",
+			"focus:outline-focus-dark",
+			"focus:outline-offset-2",
+			"focus:outline",
+			"h-8",
+			"hover:bg-action-light-hover",
+			"hover:text-copy-light-hover",
+			"inline-flex",
+			"items-center",
+			"justify-center",
+			"not-prose",
+			"p-1",
+			"rounded-full",
+			"w-8",
+		]);
+	});
+
+	it("should render a light copy button with light focus", async () => {
+		render(
+			<Bubble
+				kind="left"
+				copyToClipboard
+				copyToClipboardMode="light"
+				copyToClipboardFocusMode="light"
+			>
+				hello
+			</Bubble>,
+		);
+		await screen.findByText("hello");
+		await screen.findByLabelText("Copy to clipboard");
+		const button = await screen.findByRole("button");
+		expect(button).toBeInTheDocument();
+		expectToHaveClasses(button, [
+			BUTTON_CLASSNAME,
+			"active:bg-action-light-active",
+			"active:text-copy-light-active",
+			"border-transparent",
+			"border",
+			"focus:outline-2",
+			"focus:outline-focus-light",
+			"focus:outline-offset-2",
+			"focus:outline",
+			"h-8",
+			"hover:bg-action-light-hover",
+			"hover:text-copy-light-hover",
+			"inline-flex",
+			"items-center",
+			"justify-center",
+			"not-prose",
+			"p-1",
+			"rounded-full",
+			"w-8",
+		]);
+	});
+
+	it("should render a light copy button with dark focus", async () => {
+		render(
+			<Bubble
+				kind="left"
+				copyToClipboard
+				copyToClipboardMode="light"
+				copyToClipboardFocusMode="dark"
+			>
+				hello
+			</Bubble>,
+		);
+		await screen.findByText("hello");
+		await screen.findByLabelText("Copy to clipboard");
+		const button = await screen.findByRole("button");
+		expect(button).toBeInTheDocument();
+		expectToHaveClasses(button, [
+			BUTTON_CLASSNAME,
+			"not-prose",
+			"rounded-full",
+			"inline-flex",
+			"items-center",
+			"justify-center",
+			"h-8",
+			"w-8",
+			"p-1",
+			"border",
+			"border-transparent",
+			"focus:outline",
+			"focus:outline-2",
+			"focus:outline-offset-2",
+			"focus:outline-focus-dark",
+			"hover:text-copy-light-hover",
+			"hover:bg-action-light-hover",
+			"active:text-copy-light-active",
+			"active:bg-action-light-active",
 		]);
 	});
 });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced new customization options for the `Bubble` component, including `copyToClipboardMode` and `copyToClipboardFocusMode`, allowing users to specify the color and focus color of the Copy Button.
- **Tests**
	- Added new tests to ensure the `Bubble` component correctly renders various types of copy buttons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->