### PR TITLE
fix(ui-styles): h1 to h6 should not be bold

### DIFF
--- a/packages/documentation/src/Styles/QuickStart.stories.tsx
+++ b/packages/documentation/src/Styles/QuickStart.stories.tsx
@@ -40,6 +40,20 @@ export default twPlugin.merge({
 			</code>
 		</pre>
 
+		<p>
+			Finally, while our Typography styles could be used as is, some styles are
+			taking advantage of the Open Sans font if it is available. To add it to
+			your project, simply copy the following lines in your index.html{" "}
+			<code>head</code>:
+		</p>
+		<pre>
+			<code>
+				{`<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Open+Sans&display=swap" rel="stylesheet">`}
+			</code>
+		</pre>
+
 		<h2>Usage</h2>
 		<p>
 			Now you can use the <code>prose-dark</code>,<code>prose-light</code> and{" "}

--- a/packages/ui-styles/src/plugins/tailwindcss/typography.ts
+++ b/packages/ui-styles/src/plugins/tailwindcss/typography.ts
@@ -13,6 +13,7 @@ export default {
 						maxWidth: "inherit",
 						"h1, h2, h3, h4, h5, h6": {
 							fontFamily: "Open Sans, ui-sans-serif, system-ui, sans-serif",
+							fontWeight: "400",
 						},
 						blockquote: {
 							borderLeftWidth: "6px",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Added a new section in the Quick Start guide for integrating Open Sans font into projects.
- **Style**
	- Updated typography styles to include a default font weight of 400 for headings (`h1`-`h6`).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->