### PR TITLE
chore: remove some builds during the release-please process

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -37,7 +37,7 @@ jobs:
         run: |
           corepack enable
           pnpm install
-          npx lerna run build --ignore @versini/documentation
+          npx lerna run build --ignore "@versini/example-*" --ignore @versini/documentation --ignore @versini/bundlesize
 
       # Release Please has already incremented versions
       # and published tags, so we just need to publish


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the build process to exclude specific packages (`@versini/example-*`, `@versini/bundlesize`, and `@versini/documentation`) from the build command.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->