### PR TITLE
docs: enable full screen mode via "f" hotkey

### DIFF
--- a/packages/documentation/.ladle/components.tsx
+++ b/packages/documentation/.ladle/components.tsx
@@ -60,8 +60,6 @@ export const Provider: GlobalProvider = ({
 	storyMeta,
 	globalState,
 }) => {
-	console.log(`==> [${Date.now()}] globalState: `, globalState);
-
 	const className = clsx("prose", {
 		"mt-0 flex w-full flex-col p-2 sm:mt-3 md:mx-auto md:max-w-4xl":
 			globalState.mode === "full",

--- a/packages/documentation/.ladle/components.tsx
+++ b/packages/documentation/.ladle/components.tsx
@@ -60,13 +60,14 @@ export const Provider: GlobalProvider = ({
 	storyMeta,
 	globalState,
 }) => {
-	const className = clsx(
-		"prose mt-0 flex w-full flex-col p-2 sm:mt-3 md:mx-auto md:max-w-4xl",
-		{
-			"prose-dark dark:prose-lighter":
-				!globalState?.story.startsWith("styles--typography"),
-		},
-	);
+	console.log(`==> [${Date.now()}] globalState: `, globalState);
+
+	const className = clsx("prose", {
+		"mt-0 flex w-full flex-col p-2 sm:mt-3 md:mx-auto md:max-w-4xl":
+			globalState.mode === "full",
+		"prose-dark dark:prose-lighter":
+			!globalState?.story.startsWith("styles--typography"),
+	});
 	const handleOnClickGitHub = () => {
 		window.open(import.meta.env.REPOSITORY, "_blank", "noopener,noreferrer");
 	};

--- a/packages/documentation/.ladle/config.mjs
+++ b/packages/documentation/.ladle/config.mjs
@@ -29,7 +29,7 @@ export default {
 		previousComponent: [],
 		control: [],
 		darkMode: [],
-		fullscreen: [],
+		fullscreen: ["f"],
 		width: [],
 		rtl: [],
 		source: [],
@@ -51,7 +51,7 @@ export default {
 			enabled: false,
 		},
 		mode: {
-			enabled: false,
+			enabled: true,
 			defaultState: "full",
 		},
 		msw: {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Updated the documentation viewer with a fullscreen mode accessible via the "f" key and enabled different viewing modes for improved usability.

- **Refactor**
	- Enhanced the `Provider` component in the documentation to adapt styles dynamically based on the viewing mode, improving visual consistency and user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->