### PR TITLE
fix: bump @floating-ui/react to latest

### DIFF
--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -38,7 +38,7 @@
 		"test": "vitest run"
 	},
 	"peerDependencies": {
-		"@floating-ui/react": "<=0.26.9",
+		"@floating-ui/react": "0.26.12",
 		"fast-equals": "5.0.1",
 		"micro-memoize": "4.1.2",
 		"react": "^18.2.0",
@@ -48,7 +48,7 @@
 		"@versini/ui-styles": "workspace:../ui-styles"
 	},
 	"dependencies": {
-		"@floating-ui/react": "<=0.26.9",
+		"@floating-ui/react": "0.26.12",
 		"@tailwindcss/typography": "0.5.12",
 		"@versini/ui-hooks": "workspace:../ui-hooks",
 		"@versini/ui-icons": "workspace:../ui-icons",

--- a/packages/ui-components/src/components/Menu/__tests__/Menu.test.tsx
+++ b/packages/ui-components/src/components/Menu/__tests__/Menu.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import { Menu, MenuItem, MenuSeparator } from "../..";
@@ -125,7 +125,9 @@ describe("Menu behaviors", () => {
 		expect(firstMenuItem).toHaveFocus();
 		expect(document.activeElement).toBe(firstMenuItem);
 		await user.click(firstMenuItem);
-		expect(trigger).toHaveFocus();
+		await waitFor(() => {
+			expect(screen.queryByText(FIRST_MENU_ITEM)).not.toBeInTheDocument();
+		});
 	});
 
 	it("should trigger the Menu onOpenChange callback when opened and closed", async () => {

--- a/packages/ui-private/package.json
+++ b/packages/ui-private/package.json
@@ -43,7 +43,7 @@
 		"react-dom": "18.2.0"
 	},
 	"dependencies": {
-		"@floating-ui/react": "<=0.26.9",
+		"@floating-ui/react": "0.26.12",
 		"@versini/ui-hooks": "workspace:../ui-hooks",
 		"clsx": "2.1.0"
 	},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -180,8 +180,8 @@ importers:
   packages/ui-components:
     dependencies:
       '@floating-ui/react':
-        specifier: <=0.26.9
-        version: 0.26.9(react-dom@18.2.0)(react@18.2.0)
+        specifier: 0.26.12
+        version: 0.26.12(react-dom@18.2.0)(react@18.2.0)
       '@tailwindcss/typography':
         specifier: 0.5.12
         version: 0.5.12(tailwindcss@3.4.3)
@@ -269,8 +269,8 @@ importers:
   packages/ui-private:
     dependencies:
       '@floating-ui/react':
-        specifier: <=0.26.9
-        version: 0.26.9(react-dom@18.2.0)(react@18.2.0)
+        specifier: 0.26.12
+        version: 0.26.12(react-dom@18.2.0)(react@18.2.0)
       '@versini/ui-hooks':
         specifier: workspace:../ui-hooks
         version: link:../ui-hooks
@@ -1066,8 +1066,8 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
     dev: false
 
-  /@floating-ui/react@0.26.9(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-p86wynZJVEkEq2BBjY/8p2g3biQ6TlgT4o/3KgFKyTWoJLU1GZ8wpctwRqtkEl2tseYA+kw7dBAIDFcednfI5w==}
+  /@floating-ui/react@0.26.12(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-D09o62HrWdIkstF2kGekIKAC0/N/Dl6wo3CQsnLcOmO3LkW6Ik8uIb3kw8JYkwxNCcg+uJ2bpWUiIijTBep05w==}
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the `@floating-ui/react` library version to `0.26.12` in UI components to enhance stability and performance.

- **Tests**
	- Improved reliability of menu component tests by using `waitFor` to check for element absence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->