### PR TITLE
feat: refactor Menu to extract trigger prop

### DIFF
--- a/examples/with-vite/src/components/CustomCard.tsx
+++ b/examples/with-vite/src/components/CustomCard.tsx
@@ -1,4 +1,10 @@
-import { Card, Menu, MenuItem, Panel } from "@versini/ui-components";
+import {
+	ButtonIcon,
+	Card,
+	Menu,
+	MenuItem,
+	Panel,
+} from "@versini/ui-components";
 import {
 	IconChart,
 	IconHistory,
@@ -27,7 +33,13 @@ export const CustomCard = () => {
 							<h2 className="m-0 mb-1">Kitchen Sink</h2>
 						</FlexgridItem>
 						<FlexgridItem>
-							<Menu icon={<IconSettings />}>
+							<Menu
+								trigger={
+									<ButtonIcon>
+										<IconSettings />
+									</ButtonIcon>
+								}
+							>
 								<MenuItem
 									label="Profile"
 									icon={<IconProfile />}

--- a/examples/with-webpack/src/components/CustomCard.tsx
+++ b/examples/with-webpack/src/components/CustomCard.tsx
@@ -1,4 +1,10 @@
-import { Card, Menu, MenuItem, Panel } from "@versini/ui-components";
+import {
+	ButtonIcon,
+	Card,
+	Menu,
+	MenuItem,
+	Panel,
+} from "@versini/ui-components";
 import {
 	IconChart,
 	IconHistory,
@@ -27,7 +33,13 @@ export const CustomCard = () => {
 							<h2 className="m-0 mb-1">Kitchen Sink</h2>
 						</FlexgridItem>
 						<FlexgridItem>
-							<Menu icon={<IconSettings />}>
+							<Menu
+								trigger={
+									<ButtonIcon>
+										<IconSettings />
+									</ButtonIcon>
+								}
+							>
 								<MenuItem
 									label="Profile"
 									icon={<IconProfile />}

--- a/packages/documentation/src/Components/Header.stories.tsx
+++ b/packages/documentation/src/Components/Header.stories.tsx
@@ -143,7 +143,13 @@ const CommonTemplate = () => {
 				</Anchor>
 			</div>
 			<div className="mb-2 flex flex-wrap justify-end gap-1">
-				<Menu icon={<IconSettings />}>
+				<Menu
+					trigger={
+						<ButtonIcon>
+							<IconSettings />
+						</ButtonIcon>
+					}
+				>
 					<MenuItem label="Profile" icon={<IconProfile />} />
 					<MenuItem label="Statistics" icon={<IconChart />} />
 					<MenuItem label="History" icon={<IconHistory />} />

--- a/packages/documentation/src/Components/Menu.stories.tsx
+++ b/packages/documentation/src/Components/Menu.stories.tsx
@@ -1,6 +1,7 @@
 import type { Story } from "@ladle/react";
 import {
 	Button,
+	ButtonIcon,
 	Menu,
 	MenuItem,
 	MenuSeparator,
@@ -61,7 +62,15 @@ export const Basic: Story<any> = (args) => (
 		<Button size="small" noBorder spacing={{ r: 2 }}>
 			Button
 		</Button>
-		<Menu icon={<IconSettings />} spacing={{ r: 2 }} {...args}>
+		<Menu
+			trigger={
+				<ButtonIcon>
+					<IconSettings />
+				</ButtonIcon>
+			}
+			spacing={{ r: 2 }}
+			{...args}
+		>
 			<MenuItem label="Profile" />
 			<MenuItem label="Statistics" />
 			<MenuItem label="History" />
@@ -78,7 +87,15 @@ export const WithIcons: Story<any> = (args) => (
 		<Button size="small" spacing={{ r: 2 }}>
 			Button
 		</Button>
-		<Menu icon={<IconSettings />} spacing={{ r: 2 }} {...args}>
+		<Menu
+			trigger={
+				<ButtonIcon>
+					<IconSettings />
+				</ButtonIcon>
+			}
+			spacing={{ r: 2 }}
+			{...args}
+		>
 			<MenuItem label="Profile" icon={<IconProfile />} />
 			<MenuItem label="Statistics" icon={<IconChart />} />
 			<MenuItem label="History" icon={<IconHistory />} />
@@ -123,7 +140,15 @@ export const WithMessageBox: Story<any> = (args) => {
 				<Button size="small" spacing={{ r: 2 }}>
 					Button
 				</Button>
-				<Menu icon={<IconSettings />} spacing={{ r: 2 }} {...args}>
+				<Menu
+					trigger={
+						<ButtonIcon>
+							<IconSettings />
+						</ButtonIcon>
+					}
+					spacing={{ r: 2 }}
+					{...args}
+				>
 					<MenuItem label="Profile" icon={<IconProfile />} />
 					<MenuItem label="Statistics" icon={<IconChart />} />
 					<MenuItem label="History" icon={<IconHistory />} />

--- a/packages/documentation/src/Styles/DarkMode.stories.tsx
+++ b/packages/documentation/src/Styles/DarkMode.stories.tsx
@@ -125,7 +125,13 @@ const CommonTemplate = () => {
 				</Anchor>
 			</div>
 			<div className="mb-2 flex flex-wrap justify-end gap-1">
-				<Menu icon={<IconSettings />}>
+				<Menu
+					trigger={
+						<ButtonIcon>
+							<IconSettings />
+						</ButtonIcon>
+					}
+				>
 					<MenuItem label="Profile" icon={<IconProfile />} />
 					<MenuItem label="Statistics" icon={<IconChart />} />
 					<MenuItem label="History" icon={<IconHistory />} />

--- a/packages/ui-components/src/components/Button/ButtonTypes.d.ts
+++ b/packages/ui-components/src/components/Button/ButtonTypes.d.ts
@@ -25,6 +25,11 @@ export type CommonButtonProps = {
 	 */
 	noBorder?: boolean;
 	/**
+	 * Whether or not to render the Button with a hack for Safari click.
+	 * @default false
+	 */
+	noInternalClick?: boolean;
+	/**
 	 * Whether or not to render the Button with styles or not.
 	 * @default false
 	 */

--- a/packages/ui-components/src/components/Menu/Menu.tsx
+++ b/packages/ui-components/src/components/Menu/Menu.tsx
@@ -30,19 +30,7 @@ import React, {
 
 import { MenuContext } from "./MenuContext";
 import type { MenuProps } from "./MenuTypes";
-
-const getDisplayName = (element: React.ReactNode): string => {
-	if (typeof element === "string") {
-		return element;
-	}
-	if (typeof element === "object" && element !== null && "type" in element) {
-		const type = element.type as any;
-		if (typeof type === "function" || typeof type === "object") {
-			return type.displayName || type.name || "Component";
-		}
-	}
-	return "Element";
-};
+import { getDisplayName } from "./utilities";
 
 export const MenuComponent = forwardRef<
 	HTMLButtonElement,

--- a/packages/ui-components/src/components/Menu/Menu.tsx
+++ b/packages/ui-components/src/components/Menu/Menu.tsx
@@ -31,6 +31,19 @@ import React, {
 import { MenuContext } from "./MenuContext";
 import type { MenuProps } from "./MenuTypes";
 
+const getDisplayName = (element: React.ReactNode): string => {
+	if (typeof element === "string") {
+		return element;
+	}
+	if (typeof element === "object" && element !== null && "type" in element) {
+		const type = element.type as any;
+		if (typeof type === "function" || typeof type === "object") {
+			return type.displayName || type.name || "Component";
+		}
+	}
+	return "Element";
+};
+
 export const MenuComponent = forwardRef<
 	HTMLButtonElement,
 	MenuProps & React.HTMLProps<HTMLButtonElement>
@@ -97,19 +110,15 @@ export const MenuComponent = forwardRef<
 		const { getReferenceProps, getFloatingProps, getItemProps } =
 			useInteractions([click, role, dismiss, listNavigation, typeahead]);
 
-		let isKnownButton = false;
-		if (
-			trigger?.type?.displayName === "Button" ||
-			trigger?.type?.displayName === "ButtonIcon"
-		) {
-			isKnownButton = true;
-		}
+		const noInternalClick =
+			getDisplayName(trigger) === "Button" ||
+			getDisplayName(trigger) === "ButtonIcon";
 
 		const triggerElement = React.cloneElement(trigger as React.ReactElement, {
 			mode,
 			focusMode,
 			spacing,
-			noInternalClick: isKnownButton,
+			noInternalClick,
 			"aria-label": label,
 			"data-open": isOpen ? "" : undefined,
 			"data-focus-inside": hasFocusInside ? "" : undefined,

--- a/packages/ui-components/src/components/Menu/Menu.tsx
+++ b/packages/ui-components/src/components/Menu/Menu.tsx
@@ -20,9 +20,14 @@ import {
 	useRole,
 	useTypeahead,
 } from "@floating-ui/react";
-import { forwardRef, useContext, useEffect, useRef, useState } from "react";
+import React, {
+	forwardRef,
+	useContext,
+	useEffect,
+	useRef,
+	useState,
+} from "react";
 
-import { ButtonIcon } from "..";
 import { MenuContext } from "./MenuContext";
 import type { MenuProps } from "./MenuTypes";
 
@@ -32,9 +37,9 @@ export const MenuComponent = forwardRef<
 >(
 	(
 		{
+			trigger,
 			children,
-			label,
-			icon,
+			label = "Open menu",
 			defaultPlacement = "bottom-start",
 			onOpenChange,
 			spacing,
@@ -92,6 +97,30 @@ export const MenuComponent = forwardRef<
 		const { getReferenceProps, getFloatingProps, getItemProps } =
 			useInteractions([click, role, dismiss, listNavigation, typeahead]);
 
+		let isKnownButton = false;
+		if (
+			trigger?.type?.displayName === "Button" ||
+			trigger?.type?.displayName === "ButtonIcon"
+		) {
+			isKnownButton = true;
+		}
+
+		const triggerElement = React.cloneElement(trigger as React.ReactElement, {
+			mode,
+			focusMode,
+			spacing,
+			noInternalClick: isKnownButton,
+			"aria-label": label,
+			"data-open": isOpen ? "" : undefined,
+			"data-focus-inside": hasFocusInside ? "" : undefined,
+			ref: useMergeRefs([refs.setReference, item.ref, userRef]),
+			...getReferenceProps(
+				parent.getItemProps({
+					...props,
+				}),
+			),
+		});
+
 		// Event emitter allows you to communicate across tree components.
 		// This effect closes all menus when an item gets clicked anywhere
 		// in the tree.
@@ -121,23 +150,7 @@ export const MenuComponent = forwardRef<
 
 		return (
 			<FloatingNode id={nodeId}>
-				<ButtonIcon
-					mode={mode}
-					focusMode={focusMode}
-					spacing={spacing}
-					label={label || "Open menu"}
-					ref={useMergeRefs([refs.setReference, item.ref, userRef])}
-					data-open={isOpen ? "" : undefined}
-					data-focus-inside={hasFocusInside ? "" : undefined}
-					{...getReferenceProps(
-						parent.getItemProps({
-							...props,
-						}),
-					)}
-				>
-					{label}
-					{icon}
-				</ButtonIcon>
+				{triggerElement}
 
 				<MenuContext.Provider
 					value={{

--- a/packages/ui-components/src/components/Menu/MenuItem.tsx
+++ b/packages/ui-components/src/components/Menu/MenuItem.tsx
@@ -2,7 +2,6 @@ import { useFloatingTree, useListItem, useMergeRefs } from "@floating-ui/react";
 import clsx from "clsx";
 import * as React from "react";
 
-import { ButtonIcon } from "..";
 import { MenuContext } from "./MenuContext";
 import type { MenuItemProps, MenuSeparatorProps } from "./MenuTypes";
 
@@ -15,11 +14,9 @@ export const MenuItem = React.forwardRef<
 	const tree = useFloatingTree();
 
 	return (
-		<ButtonIcon
+		<button
 			{...props} // this needs to be first to allow override
-			raw
 			ref={useMergeRefs([item.ref, forwardedRef])}
-			type="button"
 			role="menuitem"
 			className="m-0 flex w-full rounded-md border border-transparent bg-none px-3 py-2 text-left text-base outline-none focus:border focus:border-border-medium focus:bg-surface-lighter focus:underline disabled:cursor-not-allowed disabled:text-copy-medium sm:py-1"
 			tabIndex={0}
@@ -34,10 +31,10 @@ export const MenuItem = React.forwardRef<
 					menu.setHasFocusInside(true);
 				},
 			})}
-			labelRight={label}
 		>
 			{icon}
-		</ButtonIcon>
+			{label && <span className="pl-2">{label}</span>}
+		</button>
 	);
 });
 

--- a/packages/ui-components/src/components/Menu/MenuTypes.d.ts
+++ b/packages/ui-components/src/components/Menu/MenuTypes.d.ts
@@ -1,11 +1,12 @@
 import type { Placement } from "@floating-ui/react";
 import type { SpacingProps } from "@versini/ui-private/dist/utilities";
+import React from "react";
 
 export type MenuProps = {
 	/**
 	 * The component to use to open the menu, e.g. a ButtonIcon, a Button, etc.
 	 */
-	trigger: any;
+	trigger: React.ReactNode;
 	/**
 	 * The children to render.
 	 */

--- a/packages/ui-components/src/components/Menu/MenuTypes.d.ts
+++ b/packages/ui-components/src/components/Menu/MenuTypes.d.ts
@@ -1,7 +1,11 @@
 import type { Placement } from "@floating-ui/react";
 import type { SpacingProps } from "@versini/ui-private/dist/utilities";
 
-export interface MenuProps extends SpacingProps {
+export type MenuProps = {
+	/**
+	 * The component to use to open the menu, e.g. a ButtonIcon, a Button, etc.
+	 */
+	trigger: any;
 	/**
 	 * The children to render.
 	 */
@@ -17,10 +21,6 @@ export interface MenuProps extends SpacingProps {
 	 */
 	focusMode?: "dark" | "light" | "system" | "alt-system";
 	/**
-	 * A React component of type Icon to be placed on the left of the label.
-	 */
-	icon?: React.ReactNode;
-	/**
 	 * The type of Button trigger. This will change the color of the Button.
 	 */
 	mode?: "dark" | "light" | "system" | "alt-system";
@@ -33,9 +33,9 @@ export interface MenuProps extends SpacingProps {
 	 * @param open whether or not the menu is open
 	 */
 	onOpenChange?: (open: boolean) => void;
-}
+} & SpacingProps;
 
-export interface MenuItemProps {
+export type MenuItemProps = {
 	/**
 	 * The label to use for the menu item.
 	 */
@@ -49,6 +49,6 @@ export interface MenuItemProps {
 	 * A React component of type Icon to be placed on the left of the label.
 	 */
 	icon?: React.ReactNode;
-}
+};
 
 export type MenuSeparatorProps = React.HTMLAttributes<HTMLDivElement>;

--- a/packages/ui-components/src/components/Menu/__tests__/Menu.test.tsx
+++ b/packages/ui-components/src/components/Menu/__tests__/Menu.test.tsx
@@ -1,7 +1,8 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { IconSettings } from "@versini/ui-icons";
 
-import { Menu, MenuItem, MenuSeparator } from "../..";
+import { Button, ButtonIcon, Menu, MenuItem, MenuSeparator } from "../..";
 
 const MENU_TRIGGER_LABEL = "Click Me";
 const FIRST_MENU_ITEM = "Menu 1";
@@ -11,7 +12,25 @@ const FOURTH_MENU_ITEM = "Menu 4";
 const FIFTH_MENU_ITEM = "Menu 5";
 
 const SimpleMenu = ({ ...props }) => (
-	<Menu {...props}>
+	<Menu trigger={<Button>Click Me</Button>} {...props}>
+		<MenuItem label={FIRST_MENU_ITEM} />
+		<MenuItem label={SECOND_MENU_ITEM} />
+		<MenuItem label={THIRD_MENU_ITEM} disabled />
+		<MenuItem label={FOURTH_MENU_ITEM} />
+		<MenuSeparator data-testid="menu-separator" />
+		<MenuItem label={FIFTH_MENU_ITEM} />
+	</Menu>
+);
+
+const SimpleMenuIcon = ({ ...props }) => (
+	<Menu
+		trigger={
+			<ButtonIcon>
+				<IconSettings />
+			</ButtonIcon>
+		}
+		{...props}
+	>
 		<MenuItem label={FIRST_MENU_ITEM} />
 		<MenuItem label={SECOND_MENU_ITEM} />
 		<MenuItem label={THIRD_MENU_ITEM} disabled />
@@ -37,9 +56,14 @@ describe("Menu (exceptions)", () => {
 });
 
 describe("Menu rendering", () => {
-	it("should render a menu with a trigger", () => {
+	it("should render a menu with a trigger", async () => {
 		render(<SimpleMenu />);
-		const trigger = screen.getByLabelText("Open menu");
+		const trigger = await screen.findByLabelText("Open menu");
+		expect(trigger).toBeInTheDocument();
+	});
+	it("should render a menu with a icon-only trigger", async () => {
+		render(<SimpleMenuIcon />);
+		const trigger = await screen.findByLabelText("Open menu");
 		expect(trigger).toBeInTheDocument();
 	});
 });
@@ -133,7 +157,11 @@ describe("Menu behaviors", () => {
 	it("should trigger the Menu onOpenChange callback when opened and closed", async () => {
 		const onOpenChange = vi.fn();
 		const { user } = renderWithUserEvent(
-			<Menu label={MENU_TRIGGER_LABEL} onOpenChange={onOpenChange}>
+			<Menu
+				trigger={<Button>Click Me</Button>}
+				label={MENU_TRIGGER_LABEL}
+				onOpenChange={onOpenChange}
+			>
 				<MenuItem label={FIRST_MENU_ITEM} />
 				<MenuItem label={SECOND_MENU_ITEM} />
 				<MenuItem label={THIRD_MENU_ITEM} disabled />
@@ -158,7 +186,7 @@ describe("Menu behaviors", () => {
 	it("should trigger the MenuItem onClick callback when a menuitem is selected", async () => {
 		const onClick = vi.fn();
 		const { user } = renderWithUserEvent(
-			<Menu label={MENU_TRIGGER_LABEL}>
+			<Menu trigger={<Button>Click Me</Button>} label={MENU_TRIGGER_LABEL}>
 				<MenuItem label={FIRST_MENU_ITEM} onClick={onClick} />
 				<MenuItem label={SECOND_MENU_ITEM} />
 				<MenuItem label={THIRD_MENU_ITEM} disabled />
@@ -180,7 +208,7 @@ describe("Menu behaviors", () => {
 	it("should trigger the MenuItem onFocus callback when a menuitem is selected", async () => {
 		const onFocus = vi.fn();
 		const { user } = renderWithUserEvent(
-			<Menu label={MENU_TRIGGER_LABEL}>
+			<Menu trigger={<Button>Click Me</Button>} label={MENU_TRIGGER_LABEL}>
 				<MenuItem label={FIRST_MENU_ITEM} onFocus={onFocus} />
 				<MenuItem label={SECOND_MENU_ITEM} />
 				<MenuItem label={THIRD_MENU_ITEM} disabled />

--- a/packages/ui-components/src/components/Menu/__tests__/utilities.test.tsx
+++ b/packages/ui-components/src/components/Menu/__tests__/utilities.test.tsx
@@ -1,0 +1,98 @@
+import { Component } from "react";
+import { getDisplayName } from "../utilities";
+
+describe("getDisplayName", () => {
+	it("returns display name for component when displayName is set", () => {
+		const Simple = () => {
+			return <div />;
+		};
+		Simple.displayName = "Simple";
+		expect(getDisplayName(Simple as any)).toBe("Simple");
+	});
+
+	it("returns display name of html string component", () => {
+		expect(getDisplayName("input")).toBe("input");
+	});
+
+	it("returns default display name for stateless named functions", () => {
+		const Named = function Example() {};
+		expect(getDisplayName(Named)).toBe("Example");
+	});
+
+	it("returns display name for component", () => {
+		class Simple extends Component {
+			render() {
+				return <div />;
+			}
+		}
+		expect(getDisplayName(Simple)).toBe("Simple");
+	});
+
+	it("returns display name for component when displayName is set from static initializer", () => {
+		class Simple extends Component {
+			static displayName = "Simple";
+			render() {
+				return <div />;
+			}
+		}
+		expect(getDisplayName(Simple)).toBe("Simple");
+	});
+
+	it("returns display name for a stateless component", () => {
+		const Simple = () => <div />;
+
+		expect(getDisplayName(Simple)).toBe("Simple");
+	});
+
+	it("returns default display name for stateless assigned functions", () => {
+		const Assigned = function () {};
+		expect(getDisplayName(Assigned)).toBe("Assigned");
+	});
+
+	it("returns default display name for stateless anonymous functions", () => {
+		expect(getDisplayName(() => {})).toBe("Component");
+	});
+
+	it("returns default display name for stateless arrow functions", () => {
+		expect(getDisplayName(() => <div />)).toBe("Component");
+	});
+
+	it("should return 'Element' for invalid element", () => {
+		expect(getDisplayName(null)).toBe("Element");
+	});
+
+	it("should return display name for named function with displayName", () => {
+		const NotSimple = () => {
+			return <div />;
+		};
+		NotSimple.displayName = "Simple";
+		expect(getDisplayName(NotSimple)).toBe("Simple");
+	});
+
+	it("should return display name for object with displayName on type", () => {
+		const NotSimple = {
+			type: {},
+		};
+		NotSimple.type = {
+			displayName: "Simple",
+		};
+		expect(getDisplayName(NotSimple)).toBe("Simple");
+	});
+
+	it("should return display name for object with name on type", () => {
+		const NotSimple = {
+			type: {},
+		};
+		NotSimple.type = {
+			name: "Simple",
+		};
+		expect(getDisplayName(NotSimple)).toBe("Simple");
+	});
+
+	it("should return Component for object with no name or displayName", () => {
+		const NotSimple = {
+			type: {},
+		};
+		expect(getDisplayName(NotSimple)).toBe("Component");
+	});
+});

--- a/packages/ui-components/src/components/Menu/utilities.ts
+++ b/packages/ui-components/src/components/Menu/utilities.ts
@@ -1,0 +1,15 @@
+export const getDisplayName = (element: any): string => {
+	if (typeof element === "string") {
+		return element;
+	}
+	if (typeof element === "function") {
+		return element.displayName || element.name || "Component";
+	}
+	if (typeof element === "object" && element !== null && "type" in element) {
+		const type = element.type as any;
+		if (typeof type === "function" || typeof type === "object") {
+			return type.displayName || type.name || "Component";
+		}
+	}
+	return "Element";
+};

--- a/packages/ui-components/src/components/private/BaseButton.tsx
+++ b/packages/ui-components/src/components/private/BaseButton.tsx
@@ -18,25 +18,32 @@ import type { ButtonProps } from "../Button/ButtonTypes";
  */
 const internalClick = (
 	e: React.MouseEvent<HTMLButtonElement, MouseEvent>,
+	noInternalClick: boolean,
 	onClick?: (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void,
 ) => {
-	if (!document.activeElement || document.activeElement !== e.currentTarget) {
+	if (
+		!noInternalClick &&
+		(!document.activeElement || document.activeElement !== e.currentTarget)
+	) {
 		typeof e?.currentTarget?.focus === "function" && e.currentTarget.focus();
 	}
+
 	typeof onClick === "function" && onClick(e);
 };
 
 export const BaseButton = React.forwardRef<HTMLButtonElement, ButtonProps>(
 	(buttonProps: any, ref) => {
-		const { onClick, ...otherProps } = buttonProps;
+		const { onClick, noInternalClick = false, ...otherProps } = buttonProps;
 		return (
 			<button
 				ref={ref}
 				onClick={(e) => {
-					internalClick(e, onClick);
+					internalClick(e, noInternalClick, onClick);
 				}}
 				{...otherProps}
 			/>
 		);
 	},
 );
+
+BaseButton.displayName = "BaseButton";


### PR DESCRIPTION
This is a breaking change, but we are in alpha so no major version bump

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Updated the Menu component to use a ButtonIcon as a trigger across various components.
	- Added a new property `noInternalClick` to control internal click behavior in buttons for Safari compatibility.

- **Refactor**
	- Refactored the Menu component to handle triggers and labels more efficiently.
	- Replaced the ButtonIcon with a standard button in the MenuItem component, adjusting props accordingly.

- **Documentation**
	- Updated story files to reflect changes in Menu and Button components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->