### PR TITLE
fix(Menu): return focus to trigger on close

### DIFF
--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -14,9 +14,7 @@
 	"type": "module",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",
-	"files": [
-		"dist"
-	],
+	"files": ["dist"],
 	"scripts": {
 		"build:check": "tsc",
 		"build:js": "vite build",
@@ -38,7 +36,7 @@
 		"test": "vitest run"
 	},
 	"peerDependencies": {
-		"@floating-ui/react": "0.26.12",
+		"@floating-ui/react": "0.26.13",
 		"fast-equals": "5.0.1",
 		"micro-memoize": "4.1.2",
 		"react": "^18.2.0",
@@ -48,7 +46,7 @@
 		"@versini/ui-styles": "workspace:../ui-styles"
 	},
 	"dependencies": {
-		"@floating-ui/react": "0.26.12",
+		"@floating-ui/react": "0.26.13",
 		"@tailwindcss/typography": "0.5.12",
 		"@versini/ui-hooks": "workspace:../ui-hooks",
 		"@versini/ui-icons": "workspace:../ui-icons",
@@ -56,7 +54,5 @@
 		"clsx": "2.1.1",
 		"tailwindcss": "3.4.3"
 	},
-	"sideEffects": [
-		"**/*.css"
-	]
+	"sideEffects": ["**/*.css"]
 }

--- a/packages/ui-components/src/components/Menu/__tests__/Menu.test.tsx
+++ b/packages/ui-components/src/components/Menu/__tests__/Menu.test.tsx
@@ -149,6 +149,7 @@ describe("Menu behaviors", () => {
 		expect(firstMenuItem).toHaveFocus();
 		expect(document.activeElement).toBe(firstMenuItem);
 		await user.click(firstMenuItem);
+		expect(trigger).toHaveFocus();
 		await waitFor(() => {
 			expect(screen.queryByText(FIRST_MENU_ITEM)).not.toBeInTheDocument();
 		});
@@ -179,6 +180,7 @@ describe("Menu behaviors", () => {
 		expect(firstMenuItem).toHaveFocus();
 		expect(document.activeElement).toBe(firstMenuItem);
 		await user.click(firstMenuItem);
+		expect(trigger).toHaveFocus();
 
 		expect(onOpenChange).toHaveBeenCalledWith(false);
 	});
@@ -202,6 +204,7 @@ describe("Menu behaviors", () => {
 		expect(firstMenuItem).toHaveFocus();
 		expect(document.activeElement).toBe(firstMenuItem);
 		await user.click(firstMenuItem);
+		expect(trigger).toHaveFocus();
 		expect(onClick).toHaveBeenCalled();
 	});
 
@@ -224,6 +227,7 @@ describe("Menu behaviors", () => {
 		expect(firstMenuItem).toHaveFocus();
 		expect(document.activeElement).toBe(firstMenuItem);
 		await user.click(firstMenuItem);
+		expect(trigger).toHaveFocus();
 		expect(onFocus).toHaveBeenCalled();
 	});
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -177,8 +177,8 @@ importers:
   packages/ui-components:
     dependencies:
       '@floating-ui/react':
-        specifier: 0.26.12
-        version: 0.26.12(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        specifier: 0.26.13
+        version: 0.26.13(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@tailwindcss/typography':
         specifier: 0.5.12
         version: 0.5.12(tailwindcss@3.4.3)
@@ -824,6 +824,12 @@ packages:
 
   '@floating-ui/react@0.26.12':
     resolution: {integrity: sha512-D09o62HrWdIkstF2kGekIKAC0/N/Dl6wo3CQsnLcOmO3LkW6Ik8uIb3kw8JYkwxNCcg+uJ2bpWUiIijTBep05w==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+
+  '@floating-ui/react@0.26.13':
+    resolution: {integrity: sha512-kBa9wntpugzrZ8t/4yWelvSmEKZdeTXTJzrxqyrLmcU/n1SM4nvse8yQh2e1b37rJGvtu0EplV9+IkBrCJ1vkw==}
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
@@ -7380,6 +7386,14 @@ snapshots:
       react-dom: 18.2.0(react@18.2.0)
 
   '@floating-ui/react@0.26.12(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@floating-ui/react-dom': 2.0.8(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@floating-ui/utils': 0.2.1
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+      tabbable: 6.2.0
+
+  '@floating-ui/react@0.26.13(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@floating-ui/react-dom': 2.0.8(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@floating-ui/utils': 0.2.1


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced user interaction with menu components by ensuring the trigger element gains focus after being clicked.

- **Chores**
	- Updated dependencies for improved stability and performance, including an upgrade to `@floating-ui/react`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->