### PR TITLE
fix(Typography): pre background color is too light

### DIFF
--- a/packages/ui-styles/src/plugins/tailwindcss/typography.ts
+++ b/packages/ui-styles/src/plugins/tailwindcss/typography.ts
@@ -102,7 +102,7 @@ export default {
 						"--tw-prose-captions": theme("colors.slate[700]"),
 						"--tw-prose-code": theme("colors.slate[900]"),
 						"--tw-prose-pre-code": tokens.colors["copy-lighter"],
-						"--tw-prose-pre-bg": tokens.colors["surface-medium"],
+						"--tw-prose-pre-bg": tokens.colors["surface-darker"],
 						"--tw-prose-kbd": theme("colors.slate[800]"),
 						li: {
 							color: tokens.colors["copy-dark"],


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Updated the background color for pre-formatted text to a darker shade for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->