### PR TITLE
feat(Card): adding support for darker mode and noBorder options

### DIFF
--- a/packages/documentation/src/Components/Card.stories.tsx
+++ b/packages/documentation/src/Components/Card.stories.tsx
@@ -9,10 +9,11 @@ export default {
 	args: {
 		mode: "system",
 		compact: false,
+		noBorder: false,
 	},
 	argTypes: {
 		mode: {
-			options: ["dark", "light", "system", "alt-system"],
+			options: ["dark", "light", "system", "alt-system", "darker"],
 			control: { type: "radio" },
 		},
 	},

--- a/packages/ui-components/src/components/Card/Card.tsx
+++ b/packages/ui-components/src/components/Card/Card.tsx
@@ -40,6 +40,7 @@ export const Card = ({
 	spacing,
 	mode = "system",
 	compact = false,
+	noBorder = false,
 
 	...otherProps
 }: CardProps) => {
@@ -57,6 +58,7 @@ export const Card = ({
 		spacing,
 		mode,
 		compact,
+		noBorder,
 	});
 
 	if (isHeaderString) {

--- a/packages/ui-components/src/components/Card/CardTypes.d.ts
+++ b/packages/ui-components/src/components/Card/CardTypes.d.ts
@@ -41,7 +41,12 @@ export type CardProps = {
 	/**
 	 * The mode of Card. This will change the color of the Card.
 	 */
-	mode?: "dark" | "light" | "system" | "alt-system";
+	mode?: "darker" | "dark" | "light" | "system" | "alt-system";
+	/**
+	 * Whether or not to render the Card with a border.
+	 * @default false
+	 */
+	noBorder?: boolean;
 } & SpacingProps;
 
 export type CardHeaderProps = {

--- a/packages/ui-components/src/components/Card/__tests__/Card.test.tsx
+++ b/packages/ui-components/src/components/Card/__tests__/Card.test.tsx
@@ -75,6 +75,37 @@ describe("Card modifiers", () => {
 		]);
 	});
 
+	it("should render a darker card", async () => {
+		const { container } = render(<Card mode="darker">{cardContent}</Card>);
+		const card = container.children[0];
+		expectToHaveClasses(card, [
+			CARD_CLASSNAME,
+			"bg-surface-darker",
+			"border-2",
+			"border-border-accent",
+			"p-4",
+			"rounded-md",
+			"text-copy-light",
+		]);
+	});
+
+	it("should render a default card with no border", async () => {
+		const { container } = render(<Card noBorder>{cardContent}</Card>);
+		const card = container.children[0];
+		expectToHaveClasses(card, [
+			CARD_CLASSNAME,
+			"rounded-md",
+			"border-none",
+			"p-4",
+			"border-border-dark",
+			"bg-surface-lighter",
+			"text-copy-dark",
+			"dark:border-border-accent",
+			"dark:bg-surface-dark",
+			"dark:text-copy-light",
+		]);
+	});
+
 	it("should render a default compact card", async () => {
 		const { container } = render(<Card compact>{cardContent}</Card>);
 		const card = container.children[0];

--- a/packages/ui-components/src/components/Card/utilities.ts
+++ b/packages/ui-components/src/components/Card/utilities.ts
@@ -10,7 +10,8 @@ type getCardClassesProps = {
 	compact?: boolean;
 	footerClassName?: string;
 	headerClassName?: string;
-	mode?: "dark" | "light" | "system" | "alt-system";
+	mode?: "dark" | "light" | "system" | "alt-system" | "darker";
+	noBorder?: boolean;
 } & SpacingProps;
 
 export const getCardClasses = ({
@@ -21,15 +22,20 @@ export const getCardClasses = ({
 	spacing,
 	mode,
 	compact,
+	noBorder,
 }: getCardClassesProps) => {
 	const wrapper = clsx(
 		CARD_CLASSNAME,
 		className,
-		"rounded-md border-2",
+		"rounded-md",
 		getSpacing(spacing),
 		{
+			"border-none": noBorder,
+			"border-2": !noBorder,
 			"p-4": !compact,
 			"p-1 sm:p-2": compact,
+			"border-border-accent bg-surface-darker text-copy-light":
+				mode === "darker",
 			"border-border-accent bg-surface-dark text-copy-light": mode === "dark",
 			"border-border-dark bg-surface-lighter text-copy-dark": mode === "light",
 
@@ -42,6 +48,7 @@ export const getCardClasses = ({
 	const header = headerClassName
 		? headerClassName
 		: clsx(`${CARD_CLASSNAME}__header mt-0 border-b-2`, {
+				"text-copy-light border-border-accent": mode === "darker",
 				"border-border-accent": mode === "dark",
 				"border-border-medium": mode === "light",
 				"border-border-medium dark:border-border-accent": mode === "system",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added `noBorder` prop to the `Card` component, allowing cards to be rendered without borders.
  - Introduced a new `"darker"` mode option for the `Card` component, providing an additional visual style.

- **Tests**
  - Implemented new test cases to verify the rendering of cards with the `noBorder` prop and the `"darker"` mode.

- **Documentation**
  - Updated component stories to reflect the new `noBorder` prop and `"darker"` mode option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->