### PR TITLE
fix: debug param should not be required

### DIFF
--- a/packages/ui-fingerprint/src/common/fingerprint.ts
+++ b/packages/ui-fingerprint/src/common/fingerprint.ts
@@ -31,7 +31,7 @@ type FingerprintData = [
 ];
 
 export const getFingerprintData = async (
-	debug: boolean,
+	debug?: boolean,
 ): Promise<FingerprintData> => {
 	try {
 		return Promise.all([
@@ -58,7 +58,7 @@ export const getFingerprintData = async (
 	}
 };
 
-export const getFingerprintHash = async (debug: boolean): Promise<string> => {
+export const getFingerprintHash = async (debug?: boolean): Promise<string> => {
 	try {
 		const data = await getFingerprintData(debug);
 		return await hashFromString(JSON.stringify(data));

--- a/packages/ui-fingerprint/src/components/audio.ts
+++ b/packages/ui-fingerprint/src/components/audio.ts
@@ -10,7 +10,7 @@ export const emptyAudio = {
 	},
 };
 
-export const getAudio = async (debug: boolean): Promise<AudioFP> => {
+export const getAudio = async (debug?: boolean): Promise<AudioFP> => {
 	return new Promise<AudioFP>((resolve) => {
 		try {
 			const audioContext = new window.OfflineAudioContext(1, 5000, 44100);

--- a/packages/ui-fingerprint/src/components/browser.ts
+++ b/packages/ui-fingerprint/src/components/browser.ts
@@ -2,7 +2,7 @@ import type { BrowserFP } from "../common/types";
 
 export const emptyBrowser = { browser: "" };
 
-export const getBrowser = async (_debug: boolean): Promise<BrowserFP> => {
+export const getBrowser = async (_debug?: boolean): Promise<BrowserFP> => {
 	return typeof navigator === "undefined"
 		? emptyBrowser
 		: { browser: navigator.userAgent };

--- a/packages/ui-fingerprint/src/components/canvas.ts
+++ b/packages/ui-fingerprint/src/components/canvas.ts
@@ -6,7 +6,7 @@ export const emptyCanvas = {
 		data: "",
 	},
 };
-export const getCanvas = async (debug: boolean): Promise<CanvasFP> => {
+export const getCanvas = async (debug?: boolean): Promise<CanvasFP> => {
 	const WIDTH = 300;
 	const HEIGHT = 30;
 

--- a/packages/ui-fingerprint/src/components/fonts.ts
+++ b/packages/ui-fingerprint/src/components/fonts.ts
@@ -54,7 +54,7 @@ const fontList = [
 	"ZWAdobeF",
 ] as const;
 
-export const getFonts = async (_debug: boolean): Promise<FontsFP> => {
+export const getFonts = async (_debug?: boolean): Promise<FontsFP> => {
 	return withIframe(async (_, { document }) => {
 		const holder = document.body;
 		holder.style.fontSize = textSize;

--- a/packages/ui-fingerprint/src/components/hardware.ts
+++ b/packages/ui-fingerprint/src/components/hardware.ts
@@ -56,7 +56,7 @@ const getMemoryInfo = () =>
 		jsHeapSizeLimit: 0,
 	};
 
-export const getHardware = async (debug: boolean): Promise<HardwareFP> => {
+export const getHardware = async (debug?: boolean): Promise<HardwareFP> => {
 	return new Promise((resolve) => {
 		try {
 			const deviceMemory = getDeviceMemory();

--- a/packages/ui-fingerprint/src/components/locale.ts
+++ b/packages/ui-fingerprint/src/components/locale.ts
@@ -5,7 +5,7 @@ export const emptyLocales = {
 		timezone: "",
 	},
 };
-export const getLocales = async (_debug: boolean): Promise<LocalesFP> => {
+export const getLocales = async (_debug?: boolean): Promise<LocalesFP> => {
 	return new Promise((resolve) => {
 		resolve({
 			locales: {

--- a/packages/ui-fingerprint/src/components/screen.ts
+++ b/packages/ui-fingerprint/src/components/screen.ts
@@ -10,7 +10,7 @@ export const emptyScreen = {
 	},
 };
 
-export const getScreen = async (debug: boolean): Promise<ScreenFP> => {
+export const getScreen = async (debug?: boolean): Promise<ScreenFP> => {
 	return new Promise<ScreenFP>((resolve) => {
 		try {
 			const screen = window.screen;

--- a/packages/ui-fingerprint/src/components/system.ts
+++ b/packages/ui-fingerprint/src/components/system.ts
@@ -1,6 +1,6 @@
 import type { SystemFP } from "../common/types";
 
-export const getSystem = async (debug: boolean): Promise<SystemFP> => {
+export const getSystem = async (debug?: boolean): Promise<SystemFP> => {
 	try {
 		return {
 			system: {


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Made `debug` parameter optional in multiple functions across various components.
- Updated functions in `fingerprint.ts`, `audio.ts`, `browser.ts`, `canvas.ts`, `fonts.ts`, `hardware.ts`, `locale.ts`, `screen.ts`, and `system.ts` to reflect this change.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><details><summary>9 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>fingerprint.ts</strong><dd><code>Make `debug` parameter optional in fingerprint functions</code>&nbsp; </dd></summary>
<hr>

packages/ui-fingerprint/src/common/fingerprint.ts

<li>Made <code>debug</code> parameter optional in <code>getFingerprintData</code> and <br><code>getFingerprintHash</code> functions.<br>


</details>


  </td>
  <td><a href="https://github.com/aversini/ui-components/pull/592/files#diff-2b944da987f50f2d3e783b6e102884ae859f65bc674688b542b5e26576b15ea3">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>audio.ts</strong><dd><code>Make `debug` parameter optional in audio component</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/ui-fingerprint/src/components/audio.ts

- Made `debug` parameter optional in `getAudio` function.



</details>


  </td>
  <td><a href="https://github.com/aversini/ui-components/pull/592/files#diff-e1b2946cdbd3ff235dcc8126fd4eadde7b5ac5f42a8cd43ccd13bf7d70b33212">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>browser.ts</strong><dd><code>Make `debug` parameter optional in browser component</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/ui-fingerprint/src/components/browser.ts

- Made `debug` parameter optional in `getBrowser` function.



</details>


  </td>
  <td><a href="https://github.com/aversini/ui-components/pull/592/files#diff-bcb61015a33d02e92cbed739dabefd757655a24abcf8b9b8806b1d450ea5b9b8">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>canvas.ts</strong><dd><code>Make `debug` parameter optional in canvas component</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/ui-fingerprint/src/components/canvas.ts

- Made `debug` parameter optional in `getCanvas` function.



</details>


  </td>
  <td><a href="https://github.com/aversini/ui-components/pull/592/files#diff-e4c67d9fc77cde065ec9ac0131bf83396251bff417924d7875146923e91e30c7">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>fonts.ts</strong><dd><code>Make `debug` parameter optional in fonts component</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/ui-fingerprint/src/components/fonts.ts

- Made `debug` parameter optional in `getFonts` function.



</details>


  </td>
  <td><a href="https://github.com/aversini/ui-components/pull/592/files#diff-13f70fac3638c4dc5491645c3af8f92cb6b47f6ad41c88bc72b8cb1435068333">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>hardware.ts</strong><dd><code>Make `debug` parameter optional in hardware component</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/ui-fingerprint/src/components/hardware.ts

- Made `debug` parameter optional in `getHardware` function.



</details>


  </td>
  <td><a href="https://github.com/aversini/ui-components/pull/592/files#diff-1b1eb6d2074b49c52af3d132cdcf455748bc626a92ee0e8d011300d5bfce1417">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>locale.ts</strong><dd><code>Make `debug` parameter optional in locale component</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/ui-fingerprint/src/components/locale.ts

- Made `debug` parameter optional in `getLocales` function.



</details>


  </td>
  <td><a href="https://github.com/aversini/ui-components/pull/592/files#diff-eb4d5e99e954b49b148925d879f2432c7f8f2c7694d017208b5c808503001f28">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>screen.ts</strong><dd><code>Make `debug` parameter optional in screen component</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/ui-fingerprint/src/components/screen.ts

- Made `debug` parameter optional in `getScreen` function.



</details>


  </td>
  <td><a href="https://github.com/aversini/ui-components/pull/592/files#diff-455cb14eded0cfbcf2ef3e1ac4db2bd2a13f6f20770711b91b6c068bbcacb95d">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>system.ts</strong><dd><code>Make `debug` parameter optional in system component</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/ui-fingerprint/src/components/system.ts

- Made `debug` parameter optional in `getSystem` function.



</details>


  </td>
  <td><a href="https://github.com/aversini/ui-components/pull/592/files#diff-cc9ee437d754149edddb45d314cd597f79cbc662e06b7152f65708b7120f3f80">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></details></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

