### PR TITLE
fix(TextInput): first render is sometimes leaking out of the page

### DIFF
--- a/packages/ui-form/src/components/TextInput/TextInput.tsx
+++ b/packages/ui-form/src/components/TextInput/TextInput.tsx
@@ -1,7 +1,7 @@
-import React, { useLayoutEffect, useRef, useState } from "react";
-
-import { useUniqueId } from "@versini/ui-hooks";
+import { useResizeObserver, useUniqueId } from "@versini/ui-hooks";
 import { LiveRegion } from "@versini/ui-private";
+import React, { useLayoutEffect, useState } from "react";
+
 import { TEXT_INPUT_CLASSNAME } from "../../common/constants";
 import type { TextInputProps } from "./TextInputTypes";
 import { getTextInputClasses } from "./utilities";
@@ -35,7 +35,7 @@ export const TextInput = React.forwardRef<HTMLInputElement, TextInputProps>(
 		},
 		ref,
 	) => {
-		const rightElementRef = useRef<HTMLDivElement>(null);
+		const [rightElementRef, rect] = useResizeObserver<HTMLDivElement>();
 		const [inputPaddingRight, setInputPaddingRight] = useState(0);
 		const inputId = useUniqueId({ id, prefix: `${TEXT_INPUT_CLASSNAME}-` });
 		const liveErrorMessage = `${name} error, ${helperText}`;
@@ -51,11 +51,20 @@ export const TextInput = React.forwardRef<HTMLInputElement, TextInputProps>(
 			mode,
 		});
 
+		/* c8 ignore start - ResizeObserver is tough to test... */
 		useLayoutEffect(() => {
-			if (rightElementRef.current) {
-				setInputPaddingRight(rightElementRef.current.offsetWidth + 18 + 10);
+			if (rect.width) {
+				/**
+				 * - rect.width is the width of the right element (Button, Icon, etc.)
+				 * - The main input field has default left/right paddings of
+				 *   16px (px-4) + 2px border (border-2) = 18px
+				 * - We add 10px to the right padding to give some space between the right
+				 *   element and the input field.
+				 */
+				setInputPaddingRight(rect.width + 18 + 10);
 			}
-		}, []);
+		}, [rect.width]);
+		/* c8 ignore end */
 
 		return (
 			<div className={textInputClassName.wrapper}>

--- a/packages/ui-form/src/components/TextInput/TextInput.tsx
+++ b/packages/ui-form/src/components/TextInput/TextInput.tsx
@@ -53,7 +53,7 @@ export const TextInput = React.forwardRef<HTMLInputElement, TextInputProps>(
 
 		/* c8 ignore start - ResizeObserver is tough to test... */
 		useLayoutEffect(() => {
-			if (rect.width) {
+			if (rect && rect.width) {
 				/**
 				 * - rect.width is the width of the right element (Button, Icon, etc.)
 				 * - The main input field has default left/right paddings of
@@ -63,7 +63,7 @@ export const TextInput = React.forwardRef<HTMLInputElement, TextInputProps>(
 				 */
 				setInputPaddingRight(rect.width + 18 + 10);
 			}
-		}, [rect.width]);
+		}, [rect]);
 		/* c8 ignore end */
 
 		return (


### PR DESCRIPTION
### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fixed an issue where the first render of `TextInput` was sometimes leaking out of the page by using the `useResizeObserver` hook.
- Adjusted the input padding dynamically based on the width of the right element (e.g., Button, Icon).
- Improved the readability of import statements.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>TextInput.tsx</strong><dd><code>Fix input padding issue by using `useResizeObserver` hook</code></dd></summary>
<hr>

packages/ui-form/src/components/TextInput/TextInput.tsx

<li>Added <code>useResizeObserver</code> hook to manage right element width.<br> <li> Updated <code>useLayoutEffect</code> to adjust input padding based on <code>rect.width</code>.<br> <li> Improved import statements for better readability.<br>


</details>


  </td>
  <td><a href="https://github.com/aversini/ui-components/pull/602/files#diff-94d0ce9a18396d9230bf49ba7239c330b985a43799751f515765c94c0b0c26f7">+16/-7</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

